### PR TITLE
Add RegisterTo<TService, TTarget> method

### DIFF
--- a/LightInject.SampleLibrary/Foo.cs
+++ b/LightInject.SampleLibrary/Foo.cs
@@ -25,8 +25,18 @@ namespace LightInject.SampleLibrary
     public class Foo : IFoo
     {
         public static int Instances { get; set; }
-        
+
         public Foo()
+        {
+            Instances++;
+        }
+    }
+
+    public class FooBar : IFoo, IBar
+    {
+        public static int Instances { get; set; }
+
+        public FooBar()
         {
             Instances++;
         }

--- a/LightInject.Tests/ServiceContainerTests.cs
+++ b/LightInject.Tests/ServiceContainerTests.cs
@@ -424,6 +424,23 @@ namespace LightInject.Tests
 
         }
 
+        [TestMethod]
+        public void GetInstance_RegisteredTo_PerScopeService_ReturnsSingleInstance()
+        {
+            var container = CreateContainer();
+            container.Register<FooBar>(new PerScopeLifetime());
+            container.RegisterTo<IFoo, FooBar>();
+            container.RegisterTo<IBar, FooBar>();
+            using (container.BeginScope())
+            {
+                var instanceFooBar = container.GetInstance<FooBar>();
+                var instance1 = container.GetInstance<IFoo>();
+                var instance2 = container.GetInstance<IBar>();
+
+                Assert.AreSame(instanceFooBar, instance2);
+                Assert.AreSame(instance1, instance2);
+            }
+        }
 
         #region Func Services
 

--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -121,6 +121,30 @@ namespace LightInject
         void Register<TService, TImplementation>(string serviceName, ILifetime lifetime) where TImplementation : TService;
 
         /// <summary>
+        /// Registers the <typeparamref name="TService"/> to use the factory to get instance of <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <typeparam name="TTarget">The target type.</typeparam>
+        void RegisterTo<TService, TTarget>() where TTarget : TService;
+
+        /// <summary>
+        /// Registers the <typeparamref name="TService"/> to use the factory to get instance of <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <typeparam name="TTarget">The target type.</typeparam>
+        /// <param name="targetServiceName">The name of the service to be used for resolving.</param>
+        void RegisterTo<TService, TTarget>(string targetServiceName) where TTarget : TService;
+
+        /// <summary>
+        /// Registers the <typeparamref name="TService"/> to use the factory to get instance of <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <typeparam name="TTarget">The target type.</typeparam>
+        /// <param name="targetServiceName">The name of the service to be used for resolving.</param>
+        /// <param name="serviceName">The name of the service.</param>
+        void RegisterTo<TService, TTarget>(string targetServiceName, string serviceName) where TTarget : TService;
+
+        /// <summary>
         /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>. 
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
@@ -1431,7 +1455,7 @@ namespace LightInject
                 s => AddServiceRegistration(sr),
                 (k, existing) => UpdateServiceRegistration(existing, sr));            
         }
-      
+
         /// <summary>
         /// Registers services from the given <paramref name="assembly"/>.
         /// </summary>
@@ -1857,6 +1881,39 @@ namespace LightInject
         public void Register(Type serviceType, Type implementingType)
         {
             RegisterService(serviceType, implementingType, null, string.Empty);
+        }
+
+        /// <summary>
+        /// Registers the <typeparamref name="TService"/> to use the factory to get instance of <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <typeparam name="TTarget">The target type.</typeparam>
+        public void RegisterTo<TService, TTarget>() where TTarget : TService
+        {
+            Register<TService>(factory => factory.GetInstance<TTarget>());
+        }
+
+        /// <summary>
+        /// Registers the <typeparamref name="TService"/> to use the factory to get instance of <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <typeparam name="TTarget">The target type.</typeparam>
+        /// <param name="targetServiceName">The name of the service to be used for resolving.</param>
+        public void RegisterTo<TService, TTarget>(string targetServiceName) where TTarget : TService
+        {
+            Register<TService>(factory => factory.GetInstance<TTarget>(targetServiceName));
+        }
+
+        /// <summary>
+        /// Registers the <typeparamref name="TService"/> to use the factory to get instance of <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <typeparam name="TTarget">The target type.</typeparam>
+        /// <param name="targetServiceName">The name of the service to be used for resolving.</param>
+        /// <param name="serviceName">The name of the service.</param>
+        public void RegisterTo<TService, TTarget>(string targetServiceName, string serviceName) where TTarget : TService
+        {
+            Register<TService>(factory => factory.GetInstance<TTarget>(targetServiceName), serviceName);
         }
 
         /// <summary>


### PR DESCRIPTION
Short hand for:

``` c#
Register<TService, TTarget>(factory => factory.GetInstance<TTarget>())
```

This is useful for registering a group of interfaces that actually resolve to the same instance registered with a specific lifetime.

The following:

``` c#
var container = new ServiceContainer();
container.Register<Concrete>(new PerRequestLifeTime());
container.Register<IInterfaceOne, Concrete>(factory => factory.GetInstance<Concrete>());
container.Register<IInterfaceTwo, Concrete>(factory => factory.GetInstance<Concrete>());
```

can now be written in:

``` c#
var container = new ServiceContainer();
container.Register<Concrete>(new PerRequestLifeTime());
container.RegisterTo<IInterfaceOne, Concrete>();
container.RegisterTo<IInterfaceTwo, Concrete>();
```
