### PR TITLE
Remedy circular depndency exception being suppressed

### DIFF
--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -3178,7 +3178,10 @@ namespace LightInject
                 }
                 finally
                 {
-                    dependencyStack.Pop();
+                    if(dependencyStack.Count > 0)
+                    {
+                        dependencyStack.Pop();
+                    }
                 }
             };
         }


### PR DESCRIPTION
We had a case where there was a circular dependency but the Stack<>.Pop() call on empty stack throws it's own exception an the original exception would be effectively suppressed.

Would you like me to create some test case?
