### PR TITLE
Fix problem with ScopeManager being null.

### DIFF
--- a/LightInject.Web/LightInject.Web.cs
+++ b/LightInject.Web/LightInject.Web.cs
@@ -108,7 +108,10 @@ namespace LightInject.Web
         private static void EndRequest()
         {
             var scopeManager = (ScopeManager)HttpContext.Current.Items["ScopeManager"];
-            scopeManager.CurrentScope.Dispose();            
+            if (scopeManager != null)
+            {
+                scopeManager.CurrentScope.Dispose();
+            }
         }
 
         private static void BeginRequest()


### PR DESCRIPTION
Sometimes `ScopeManager` is not set when `EndRequest` is triggered. I found this to be the case with an Azure deployment with multiple domains and a redirect from the non-canonical domains to the canonical domains. This threw a `NullReferenceException`.

This fix has successfully been deployed to a production server.
