### PR TITLE
Use HttpApplication.Context instead of HttpContext.Current

### DIFF
--- a/LightInject.Web/LightInject.Web.cs
+++ b/LightInject.Web/LightInject.Web.cs
@@ -35,7 +35,7 @@
 
 namespace LightInject
 {
-    using LightInject.Web;
+    using Web;
     
     /// <summary>
     /// Extends the <see cref="IServiceContainer"/> interface with a method
@@ -94,8 +94,8 @@ namespace LightInject.Web
         /// <param name="context">An <see cref="HttpApplication"/> that provides access to the methods, properties, and events common to all application objects within an ASP.NET application </param>
         public void Init(HttpApplication context)
         {
-            context.BeginRequest += (s, a) => BeginRequest();
-            context.EndRequest += (s, a) => EndRequest();               
+            context.BeginRequest += BeginRequest;
+            context.EndRequest += EndRequest;
         }
 
         /// <summary>
@@ -105,20 +105,28 @@ namespace LightInject.Web
         {            
         }
        
-        private static void EndRequest()
+        private static void EndRequest(object sender, EventArgs eventArgs)
         {
-            var scopeManager = (ScopeManager)HttpContext.Current.Items["ScopeManager"];
+            var application = sender as HttpApplication;
+            if (application == null)
+                return;
+
+            var scopeManager = (ScopeManager)application.Context.Items["ScopeManager"];
             if (scopeManager != null)
             {
                 scopeManager.CurrentScope.Dispose();
             }
         }
 
-        private static void BeginRequest()
+        private static void BeginRequest(object sender, EventArgs eventArgs)
         {
+            var application = sender as HttpApplication;
+            if (application == null)
+                return;
+
             var scopeManager = new ScopeManager();
             scopeManager.BeginScope();
-            HttpContext.Current.Items["ScopeManager"] = scopeManager;
+            application.Context.Items["ScopeManager"] = scopeManager;
         }         
     }
 


### PR DESCRIPTION
I had a problem when adding the [HSTS IIS module](https://hstsiis.codeplex.com/). When redirecting from http to https, LightInject would fail with the following stack trace:

```
[NullReferenceException: Object reference not set to an instance of an object.]
   LightInject.Web.LightInjectHttpModule.EndRequest() in c:\Users\bri\Documents\GitHub\LightInject\NuGet\Build\Net45\LightInject.Web\LightInject.Web.cs:110
   System.Web.SyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +91
   System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously) +164
```

The error was caused by `HttpContext.Current` being `null`. To avoid this, I modified `LightInject.Web` to instead use the event sender's HttpContext, as this will never be null. This is also how e.g. Unity does it in [UnityPerRequestHttpModule](https://unity.codeplex.com/SourceControl/latest#source/Unity.Mvc/Src/UnityPerRequestHttpModule.cs).
