### PR TITLE
allow full file paths in assembly scanner

### DIFF
--- a/LightInject.Tests/AssemblyScannerTests.cs
+++ b/LightInject.Tests/AssemblyScannerTests.cs
@@ -224,6 +224,7 @@
             mockContext.Assert(a => a.Scan(typeof(IFoo).Assembly, The<IServiceRegistry>.IsAnyValue, The<Func<ILifetime>>.IsAnyValue, The<Func<Type, Type, bool>>.IsAnyValue), Invoked.Once);
         }
 #if NET || NET45
+
         [TestMethod]
         public void Register_SearchPattern_CallsAssemblyScanner()
         {
@@ -232,6 +233,17 @@
             var serviceContainer = new ServiceContainer();
             serviceContainer.AssemblyScanner = scannerMock;
             serviceContainer.RegisterAssembly("LightInject.SampleLibrary.dll");
+            mockContext.Assert(a => a.Scan(typeof(IFoo).Assembly, The<IServiceRegistry>.IsAnyValue, The<Func<ILifetime>>.IsAnyValue, The<Func<Type, Type, bool>>.IsAnyValue), Invoked.Once);
+        }
+
+        [TestMethod]
+        public void Register_SearchPattern_CallsAssemblyScanner_FromFullPath()
+        {
+            var mockContext = new MockContext<IAssemblyScanner>();
+            var scannerMock = new AssemblyScannerMock(mockContext);            
+            var serviceContainer = new ServiceContainer();
+            serviceContainer.AssemblyScanner = scannerMock;
+            serviceContainer.RegisterAssembly(Environment.CurrentDirectory + "\\LightInject.SampleLibrary.dll");
             mockContext.Assert(a => a.Scan(typeof(IFoo).Assembly, The<IServiceRegistry>.IsAnyValue, The<Func<ILifetime>>.IsAnyValue, The<Func<Type, Type, bool>>.IsAnyValue), Invoked.Once);
         }
 #endif

--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -6958,9 +6958,19 @@ namespace LightInject
             if (directory != null)
             {
                 string[] searchPatterns = searchPattern.Split('|');
-                foreach (string file in searchPatterns.SelectMany(sp => Directory.GetFiles(directory, sp)).Where(CanLoad))
+                foreach (string pattern in searchPatterns)
                 {
-                    yield return Assembly.LoadFrom(file);
+                    if(File.Exists(pattern))
+                    {
+                        yield return Assembly.LoadFrom(pattern);
+                    }
+                    else
+                    {
+                        foreach(string file in searchPattern.SelectMany(sp => Directory.GetFiles(directory, pattern)).Where(CanLoad))
+                        {
+                            yield return Assembly.LoadFrom(file);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
update to allow full paths for registering single assemblies, eg       
> container.RegisterAssembly(@"c:\temp\IBM.Data.DB2.10.5.3.dll");