### PR TITLE
Allow injecting dependencies on non-public properties.

### DIFF
--- a/LightInject.Tests/AnnotatedPropertiesTests.cs
+++ b/LightInject.Tests/AnnotatedPropertiesTests.cs
@@ -36,6 +36,20 @@
         }
 
         [TestMethod]
+        public void GetInstance_ClassWithPrivateAnnotatedProperties_InjectsProperty()
+        {
+            var container = (ServiceContainer)base.CreateContainer();
+            container.PropertyDependencySelector = new AnnotatedPropertyDependencySelector(new AllPropertySelector());
+
+            container.Register<IFoo, FooWithPrivateAnnotatedProperyDependency>();
+            container.Register<IBar, Bar>();
+
+            var instance = (FooWithPrivateAnnotatedProperyDependency)container.GetInstance<IFoo>();
+
+            Assert.IsNotNull(instance.GetBar());
+        }
+
+        [TestMethod]
         public void GetInstance_ClassWithAnnotatedProperties_ThrowsExceptionWhenDependencyIsMissing()
         {
             var container = CreateContainer();

--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -3727,7 +3727,7 @@ namespace LightInject
             emitter.Push(instanceVariable);
             propertyDependencyEmitMethod(emitter);                
             emitter.UnboxOrCast(propertyDependency.ServiceType);
-            emitter.Call(propertyDependency.Property.GetSetMethod());
+            emitter.Call(propertyDependency.Property.GetSetMethod(/*include non public*/ true));
         }
 
         private Action<IEmitter> GetEmitMethodForDependency(Dependency dependency)
@@ -7075,7 +7075,8 @@ namespace LightInject
 
         private static bool IsReadOnly(PropertyInfo propertyInfo)
         {
-            return propertyInfo.GetSetMethod() == null || propertyInfo.GetSetMethod().IsStatic || propertyInfo.GetSetMethod().IsPrivate || propertyInfo.GetIndexParameters().Length > 0;
+            var setMethod = propertyInfo.GetSetMethod();
+            return setMethod == null || setMethod.IsStatic || setMethod.IsPrivate || propertyInfo.GetIndexParameters().Length > 0;
         }
     }
 #if NET || NET45


### PR DESCRIPTION
While converting to LightInject I had the need to inject dependencies into private or protected properties.  

An example class:
public class Test
{
   [Dependency]
   protected IDependency Dependency { get; set; }
}

I had the need to also reuse an existing attribute to annotate the injectable properties.  Since LightInject has the IPropertySelector interface I was able to add this support easily until GetSetMethod is called in the EmitPropertyDependency method in LightInject.  This was causing a NullReferenceException.  

This pull request fixes the issue by passing true to the GetSetMethod which allows for non-public properties.  Ultimately, the usage of non-public vs public properties is controlled by the PropertySelector.  
