### PR TITLE
Feature/performance fix

### DIFF
--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -4104,6 +4104,13 @@ namespace LightInject
         {            
             lock (lockObject)
             {
+                var key = Tuple.Create(serviceType, serviceName);
+                var instanceDelegate = namedDelegates.Search(key);
+                if (instanceDelegate != null)
+                {
+                    return instanceDelegate;
+                }
+
                 var serviceEmitter = GetEmitMethod(serviceType, serviceName);
                 if (serviceEmitter == null && throwError)
                 {

--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -4040,8 +4040,7 @@ namespace LightInject
         {
             if (serviceRegistration.Lifetime is PerContainerLifetime)
             {
-                Func<object> instanceDelegate =
-                    WrapAsFuncDelegate(CreateDynamicMethodDelegate(emitMethod));                        
+                Func<object> instanceDelegate = () => WrapAsFuncDelegate(CreateDynamicMethodDelegate(emitMethod))();
                 var instance = serviceRegistration.Lifetime.GetInstance(instanceDelegate, null);
                 var instanceIndex = constants.Add(instance);
                 emitter.PushConstant(instanceIndex, instance.GetType());                


### PR DESCRIPTION
We have found and fixed two performance issues in lightinject.

1. At service cold start, we sent thousand requests to a controller. Every thread blocks at the lock object in CreateDelegate. The fix we put there is to do another cache look up before continue.

2. In EmitLifetime, if service is PerContainerLifetime, the function CreateDynamicMethodDelegate is always called regardless if the instance is cached or not. The fix is make it lazy evaluate instead. This fix speed up our controller from 12 seconds to 103 ms.
