### PR TITLE
Use TryGetInstance instead of GetInstance

### DIFF
--- a/LightInject.WebApi/LightInject.WebApi.cs
+++ b/LightInject.WebApi/LightInject.WebApi.cs
@@ -184,7 +184,7 @@ namespace LightInject.WebApi
         /// <returns>The requested service instance if available, otherwise null.</returns>                
         public object GetService(Type serviceType)
         {
-            return serviceContainer.GetInstance(serviceType);
+            return serviceContainer.TryGetInstance(serviceType);
         }
 
         /// <summary>


### PR DESCRIPTION
The dependency scope should not fail if the service is not found, rather null should be returned.