### PR TITLE
Added compilation support for DNX451 and DNXCORE50

### DIFF
--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -1,4 +1,4 @@
-/*********************************************************************************   
+/*********************************************************************************
     The MIT License (MIT)
 
     Copyright (c) 2014 bernhard.richter@gmail.com
@@ -25,35 +25,37 @@
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/
+#if !DNXCORE50
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly", Justification = "Reviewed")]
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:PrefixLocalCallsWithThis", Justification = "No inheritance")]
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:FileMayOnlyContainASingleClass", Justification = "Single source file deployment.")]
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:FileMustHaveHeader", Justification = "Custom header.")]
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "All public members are documented.")]
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldsMustBePrivate", Justification = "Performance")]
+#endif
 
 namespace LightInject
 {
-    using System;    
+    using System;
 #if WINDOWS_PHONE || IOS
     using System.Collections;
-#endif    
-#if NET || NET45 || NETFX_CORE 
+#endif
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE
     using System.Collections.Concurrent;
 #endif
     using System.Collections.Generic;
-#if NET45 || NETFX_CORE || WINDOWS_PHONE || NET || IOS
+#if NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE || NET || IOS
     using System.Collections.ObjectModel;
-#endif    
-#if NET || NET45    
+#endif
+#if NET || NET45 || DNX451 || DNXCORE50
     using System.IO;
-#endif    
+#endif
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using System.Reflection.Emit;
     using System.Runtime.CompilerServices;
-#if NET45
+#if NET45 || DNX451
     using System.Runtime.Remoting.Messaging;
 #endif
     using System.Text;
@@ -71,10 +73,10 @@ namespace LightInject
     /// Defines a set of methods used to register services into the service container.
     /// </summary>
     internal interface IServiceRegistry
-    {           
+    {
         /// <summary>
-        /// Gets a list of <see cref="ServiceRegistration"/> instances that represents the 
-        /// registered services.          
+        /// Gets a list of <see cref="ServiceRegistration"/> instances that represents the
+        /// registered services.
         /// </summary>
         IEnumerable<ServiceRegistration> AvailableServices { get; }
 
@@ -143,14 +145,14 @@ namespace LightInject
         void Register<TService, TImplementation>(string serviceName, ILifetime lifetime) where TImplementation : TService;
 
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>. 
+        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="instance">The instance returned when this service is requested.</param>
         void RegisterInstance<TService>(TService instance);
 
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>. 
+        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="instance">The instance returned when this service is requested.</param>
@@ -158,14 +160,14 @@ namespace LightInject
         void RegisterInstance<TService>(TService instance, string serviceName);
 
         /// <summary>
-        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>. 
+        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <param name="serviceType">The service type to register.</param>
         /// <param name="instance">The instance returned when this service is requested.</param>
         void RegisterInstance(Type serviceType, object instance);
 
         /// <summary>
-        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>. 
+        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <param name="serviceType">The service type to register.</param>
         /// <param name="instance">The instance returned when this service is requested.</param>
@@ -177,7 +179,7 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         void Register<TService>();
-                
+
         /// <summary>
         /// Registers a concrete type as a service.
         /// </summary>
@@ -197,200 +199,200 @@ namespace LightInject
         /// <param name="serviceType">The concrete type to register.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
         void Register(Type serviceType, ILifetime lifetime);
-       
+
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<TService>(Expression<Func<IServiceFactory, TService>> factory);
 
 #endif
-#if IOS        
+#if IOS
         void Register<TService>(Func<IServiceFactory, TService> factory);
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T">The parameter type.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T, TService>(Expression<Func<IServiceFactory, T, TService>> factory);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T, TService>(Func<IServiceFactory, T, TService> factory);
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T">The parameter type.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param> 
-        /// <param name="serviceName">The name of the service.</param>        
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+        /// <param name="serviceName">The name of the service.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T, TService>(Expression<Func<IServiceFactory, T, TService>> factory, string serviceName);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T, TService>(Func<IServiceFactory, T, TService> factory, string serviceName);
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE                
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T1, T2, TService>(Expression<Func<IServiceFactory, T1, T2, TService>> factory);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T1, T2, TService>(Func<IServiceFactory, T1, T2, TService> factory);
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
         /// <param name="serviceName">The name of the service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T1, T2, TService>(Expression<Func<IServiceFactory, T1, T2, TService>> factory, string serviceName);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T1, T2, TService>(Func<IServiceFactory, T1, T2, TService> factory, string serviceName);
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T1, T2, T3, TService>(Expression<Func<IServiceFactory, T1, T2, T3, TService>> factory);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T1, T2, T3, TService>(Func<IServiceFactory, T1, T2, T3, TService> factory);
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
         /// <param name="serviceName">The name of the service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T1, T2, T3, TService>(Expression<Func<IServiceFactory, T1, T2, T3, TService>> factory, string serviceName);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T1, T2, T3, TService>(Func<IServiceFactory, T1, T2, T3, TService> factory, string serviceName);
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T1, T2, T3, T4, TService>(Expression<Func<IServiceFactory, T1, T2, T3, T4, TService>> factory);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T1, T2, T3, T4, TService>(Func<IServiceFactory, T1, T2, T3, T4, TService> factory);
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
         /// <param name="serviceName">The name of the service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE                
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<T1, T2, T3, T4, TService>(Expression<Func<IServiceFactory, T1, T2, T3, T4, TService>> factory, string serviceName);
 
 #endif
-#if IOS        
+#if IOS
         void Register<T1, T2, T3, T4, TService>(Func<IServiceFactory, T1, T2, T3, T4, TService> factory, string serviceName);
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<TService>(Expression<Func<IServiceFactory, TService>> factory, ILifetime lifetime);
 
 #endif
 #if IOS
         void Register<TService>(Func<IServiceFactory, TService> factory, ILifetime lifetime);
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
-        /// <param name="serviceName">The name of the service.</param>        
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+        /// <param name="serviceName">The name of the service.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<TService>(Expression<Func<IServiceFactory, TService>> factory, string serviceName);
 
 #endif
-#if IOS        
+#if IOS
         void Register<TService>(Func<IServiceFactory, TService> factory, string serviceName);
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
-        /// <param name="serviceName">The name of the service.</param>        
+        /// <param name="serviceName">The name of the service.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE                
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Register<TService>(Expression<Func<IServiceFactory, TService>> factory, string serviceName, ILifetime lifetime);
 
 #endif
-#if IOS        
+#if IOS
         void Register<TService>(Func<IServiceFactory, TService> factory, string serviceName, ILifetime lifetime);
 
 #endif
@@ -414,15 +416,15 @@ namespace LightInject
         /// </summary>
         /// <param name="serviceRegistration">The <see cref="ServiceRegistration"/> instance that contains service metadata.</param>
         void Register(ServiceRegistration serviceRegistration);
-        
+
         /// <summary>
         /// Registers composition roots from the given <paramref name="assembly"/>.
         /// </summary>
-        /// <param name="assembly">The assembly to be scanned for services.</param>        
+        /// <param name="assembly">The assembly to be scanned for services.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         void RegisterAssembly(Assembly assembly);
 
         /// <summary>
@@ -431,9 +433,9 @@ namespace LightInject
         /// <param name="assembly">The assembly to be scanned for services.</param>
         /// <param name="shouldRegister">A function delegate that determines if a service implementation should be registered.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         void RegisterAssembly(Assembly assembly, Func<Type, Type, bool> shouldRegister);
 
         /// <summary>
@@ -442,9 +444,9 @@ namespace LightInject
         /// <param name="assembly">The assembly to be scanned for services.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         void RegisterAssembly(Assembly assembly, Func<ILifetime> lifetime);
 
         /// <summary>
@@ -454,9 +456,9 @@ namespace LightInject
         /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of the registered service.</param>
         /// <param name="shouldRegister">A function delegate that determines if a service implementation should be registered.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         void RegisterAssembly(Assembly assembly, Func<ILifetime> lifetimeFactory, Func<Type, Type, bool> shouldRegister);
 
         /// <summary>
@@ -466,16 +468,16 @@ namespace LightInject
         void RegisterFrom<TCompositionRoot>() where TCompositionRoot : ICompositionRoot, new();
 
         /// <summary>
-        /// Registers a factory delegate to be used when resolving a constructor dependency for 
+        /// Registers a factory delegate to be used when resolving a constructor dependency for
         /// a implicitly registered service.
         /// </summary>
         /// <typeparam name="TDependency">The dependency type.</typeparam>
         /// <param name="factory">The factory delegate used to create an instance of the dependency.</param>
         void RegisterConstructorDependency<TDependency>(
             Expression<Func<IServiceFactory, ParameterInfo, TDependency>> factory);
-        
+
         /// <summary>
-        /// Registers a factory delegate to be used when resolving a constructor dependency for 
+        /// Registers a factory delegate to be used when resolving a constructor dependency for
         /// a implicitly registered service.
         /// </summary>
         /// <typeparam name="TDependency">The dependency type.</typeparam>
@@ -483,13 +485,13 @@ namespace LightInject
         void RegisterPropertyDependency<TDependency>(
             Expression<Func<IServiceFactory, PropertyInfo, TDependency>> factory);
 
-#if NET || NET45
+#if NET || NET45 || DNX451
         /// <summary>
         /// Registers composition roots from assemblies in the base directory that matches the <paramref name="searchPattern"/>.
         /// </summary>
         /// <param name="searchPattern">The search pattern used to filter the assembly files.</param>
-        void RegisterAssembly(string searchPattern);    
-   
+        void RegisterAssembly(string searchPattern);
+
 #endif
         /// <summary>
         /// Decorates the <paramref name="serviceType"/> with the given <paramref name="decoratorType"/>.
@@ -504,7 +506,7 @@ namespace LightInject
         /// Decorates the <paramref name="serviceType"/> with the given <paramref name="decoratorType"/>.
         /// </summary>
         /// <param name="serviceType">The target service type.</param>
-        /// <param name="decoratorType">The decorator type used to decorate the <paramref name="serviceType"/>.</param>        
+        /// <param name="decoratorType">The decorator type used to decorate the <paramref name="serviceType"/>.</param>
         void Decorate(Type serviceType, Type decoratorType);
 
         /// <summary>
@@ -519,14 +521,14 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="TService">The target service type.</typeparam>
         /// <param name="factory">A factory delegate used to create a decorator instance.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         void Decorate<TService>(Expression<Func<IServiceFactory, TService, TService>> factory);
 
 #endif
-#if IOS        
+#if IOS
         void Decorate<TService>(Func<IServiceFactory, TService, TService> factory);
 
-#endif 
+#endif
         /// <summary>
         /// Registers a decorator based on a <see cref="DecoratorRegistration"/> instance.
         /// </summary>
@@ -545,13 +547,13 @@ namespace LightInject
             Func<IServiceFactory, ServiceRegistration, ServiceRegistration> serviceRegistrationFactory);
 
         /// <summary>
-        /// Allows post-processing of a service instance. 
+        /// Allows post-processing of a service instance.
         /// </summary>
         /// <param name="predicate">A function delegate that determines if the given service can be post-processed.</param>
         /// <param name="processor">An action delegate that exposes the created service instance.</param>
         void Initialize(Func<ServiceRegistration, bool> predicate, Action<IServiceFactory, object> processor);
     }
-    
+
     /// <summary>
     /// Defines a set of methods used to retrieve service instances.
     /// </summary>
@@ -588,7 +590,7 @@ namespace LightInject
         /// </summary>
         /// <param name="serviceType">The type of the requested service.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <param name="arguments">The arguments to be passed to the target instance.</param>        
+        /// <param name="arguments">The arguments to be passed to the target instance.</param>
         /// <returns>The requested service instance.</returns>
         object GetInstance(Type serviceType, string serviceName, object[] arguments);
 
@@ -612,26 +614,26 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<TService>(string serviceName);
 
         /// <summary>
         /// Gets an instance of the given <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="T">The type of the argument.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="value">The argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T, TService>(T value);
 
         /// <summary>
         /// Gets an instance of the given <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="T">The type of the parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="value">The argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T, TService>(T value, string serviceName);
 
         /// <summary>
@@ -639,10 +641,10 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T1, T2, TService>(T1 arg1, T2 arg2);
 
         /// <summary>
@@ -650,11 +652,11 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T1, T2, TService>(T1 arg1, T2 arg2, string serviceName);
 
         /// <summary>
@@ -663,11 +665,11 @@ namespace LightInject
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T1, T2, T3, TService>(T1 arg1, T2 arg2, T3 arg3);
 
         /// <summary>
@@ -676,12 +678,12 @@ namespace LightInject
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T1, T2, T3, TService>(T1 arg1, T2 arg2, T3 arg3, string serviceName);
 
         /// <summary>
@@ -691,12 +693,12 @@ namespace LightInject
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
         /// <param name="arg4">The fourth argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T1, T2, T3, T4, TService>(T1 arg1, T2 arg2, T3 arg3, T4 arg4);
 
         /// <summary>
@@ -706,13 +708,13 @@ namespace LightInject
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
         /// <param name="arg4">The fourth argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         TService GetInstance<T1, T2, T3, T4, TService>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, string serviceName);
 
         /// <summary>
@@ -781,11 +783,11 @@ namespace LightInject
     internal interface IServiceContainer : IServiceRegistry, IServiceFactory, IDisposable
     {
         /// <summary>
-        /// Gets or sets the <see cref="IScopeManagerProvider"/> that is responsible 
+        /// Gets or sets the <see cref="IScopeManagerProvider"/> that is responsible
         /// for providing the <see cref="ScopeManager"/> used to manage scopes.
         /// </summary>
         IScopeManagerProvider ScopeManagerProvider { get; set; }
-     
+
         /// <summary>
         /// Returns <b>true</b> if the container can create the requested service, otherwise <b>false</b>.
         /// </summary>
@@ -793,13 +795,13 @@ namespace LightInject
         /// <param name="serviceName">The name of the service.</param>
         /// <returns><b>true</b> if the container can create the requested service, otherwise <b>false</b>.</returns>
         bool CanGetInstance(Type serviceType, string serviceName);
-        
+
         /// <summary>
         /// Injects the property dependencies for a given <paramref name="instance"/>.
         /// </summary>
         /// <param name="instance">The target instance for which to inject its property dependencies.</param>
         /// <returns>The <paramref name="instance"/> with its property dependencies injected.</returns>
-        object InjectProperties(object instance);        
+        object InjectProperties(object instance);
     }
 
     /// <summary>
@@ -883,7 +885,7 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Represents a class that is capable of building a <see cref="ConstructorInfo"/> instance 
+    /// Represents a class that is capable of building a <see cref="ConstructorInfo"/> instance
     /// based on a <see cref="Registration"/>.
     /// </summary>
     internal interface IConstructionInfoBuilder
@@ -909,7 +911,7 @@ namespace LightInject
         ConstructionInfo GetConstructionInfo(Registration registration);
 
         /// <summary>
-        /// Invalidates the <see cref="IConstructionInfoProvider"/> and causes new <see cref="ConstructionInfo"/> instances 
+        /// Invalidates the <see cref="IConstructionInfoProvider"/> and causes new <see cref="ConstructionInfo"/> instances
         /// to be created when the <see cref="GetConstructionInfo"/> method is called.
         /// </summary>
         void Invalidate();
@@ -942,7 +944,7 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Represents a class that selects the constructor to be used for creating a new service instance. 
+    /// Represents a class that selects the constructor to be used for creating a new service instance.
     /// </summary>
     internal interface IConstructorSelector
     {
@@ -954,7 +956,7 @@ namespace LightInject
         /// when creating a new instance of the <paramref name="implementingType"/>.</returns>
         ConstructorInfo Execute(Type implementingType);
     }
-#if NET || NET45
+#if NET || NET45 || DNX451
 
     /// <summary>
     /// Represents a class that is responsible loading a set of assemblies based on the given search pattern.
@@ -978,7 +980,7 @@ namespace LightInject
         /// <summary>
         /// Scans the target <paramref name="assembly"/> and registers services found within the assembly.
         /// </summary>
-        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>        
+        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>
         /// <param name="serviceRegistry">The target <see cref="IServiceRegistry"/> instance.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
         /// <param name="shouldRegister">A function delegate that determines if a service implementation should be registered.</param>
@@ -987,7 +989,7 @@ namespace LightInject
         /// <summary>
         /// Scans the target <paramref name="assembly"/> and executes composition roots found within the <see cref="Assembly"/>.
         /// </summary>
-        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>        
+        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>
         /// <param name="serviceRegistry">The target <see cref="IServiceRegistry"/> instance.</param>
         void Scan(Assembly assembly, IServiceRegistry serviceRegistry);
     }
@@ -1005,7 +1007,7 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Represents an abstraction of the <see cref="ILGenerator"/> class that provides information 
+    /// Represents an abstraction of the <see cref="ILGenerator"/> class that provides information
     /// about the <see cref="Type"/> currently on the stack.
     /// </summary>
     internal interface IEmitter
@@ -1032,7 +1034,7 @@ namespace LightInject
         /// <param name="code">The MSIL instruction to be put onto the stream.</param>
         /// <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
         void Emit(OpCode code, int arg);
-       
+
         /// <summary>
         /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
         /// </summary>
@@ -1053,7 +1055,7 @@ namespace LightInject
         /// <param name="code">The MSIL instruction to be put onto the stream.</param>
         /// <param name="type">A <see cref="Type"/> representing the type metadata token.</param>
         void Emit(OpCode code, Type type);
-        
+
         /// <summary>
         /// Puts the specified instruction and metadata token for the specified constructor onto the Microsoft intermediate language (MSIL) stream of instructions.
         /// </summary>
@@ -1067,7 +1069,7 @@ namespace LightInject
         /// <param name="code">The MSIL instruction to be emitted onto the stream.</param>
         /// <param name="localBuilder">A local variable.</param>
         void Emit(OpCode code, LocalBuilder localBuilder);
-        
+
         /// <summary>
         /// Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream followed by the metadata token for the given method.
         /// </summary>
@@ -1080,7 +1082,7 @@ namespace LightInject
         /// </summary>
         /// <param name="type">A <see cref="Type"/> object that represents the type of the local variable.</param>
         /// <returns>The declared local variable.</returns>
-        LocalBuilder DeclareLocal(Type type);        
+        LocalBuilder DeclareLocal(Type type);
     }
 
     /// <summary>
@@ -1091,7 +1093,7 @@ namespace LightInject
         /// <summary>
         /// Gets the <see cref="IEmitter"/> for the this dynamic method.
         /// </summary>
-        /// <returns>The <see cref="IEmitter"/> for this dynamic method.</returns>        
+        /// <returns>The <see cref="IEmitter"/> for this dynamic method.</returns>
         IEmitter GetEmitter();
 
         /// <summary>
@@ -1099,7 +1101,7 @@ namespace LightInject
         /// </summary>
         /// <param name="delegateType">A delegate type whose signature matches that of the dynamic method.</param>
         /// <returns>A delegate of the specified type, which can be used to execute the dynamic method.</returns>
-        Delegate CreateDelegate(Type delegateType); 
+        Delegate CreateDelegate(Type delegateType);
     }
 
     /// <summary>
@@ -1149,7 +1151,7 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Contains a set of helper method related to validating 
+    /// Contains a set of helper method related to validating
     /// user input.
     /// </summary>
     internal static class Ensure
@@ -1248,7 +1250,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Adds a new element to the <see cref="ImmutableHashTree{TKey,TValue}"/>. 
+        /// Adds a new element to the <see cref="ImmutableHashTree{TKey,TValue}"/>.
         /// </summary>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TValue">The type of the value.</typeparam>
@@ -1299,12 +1301,12 @@ namespace LightInject
                     }
                 }
             }
-            
+
             return default(TValue);
         }
 
         /// <summary>
-        /// Adds a new element to the <see cref="ImmutableHashTree{TKey,TValue}"/>. 
+        /// Adds a new element to the <see cref="ImmutableHashTree{TKey,TValue}"/>.
         /// </summary>
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TValue">The type of the value.</typeparam>
@@ -1410,7 +1412,7 @@ namespace LightInject
     internal static class FuncTypeExtensions
     {
         private static readonly ThreadSafeDictionary<Type, Type> FuncTypes = new ThreadSafeDictionary<Type, Type>();
-            
+
         public static Type GetFuncType(this Type returnType)
         {
             return FuncTypes.GetOrAdd(returnType, CreateFuncType);
@@ -1423,7 +1425,7 @@ namespace LightInject
     }
 
     internal static class LifetimeHelper
-    {        
+    {
         static LifetimeHelper()
         {
             GetInstanceMethod = typeof(ILifetime).GetMethod("GetInstance");
@@ -1445,7 +1447,7 @@ namespace LightInject
 
         private static readonly ThreadSafeDictionary<Type, MethodInfo> GetInstanceMethods =
             new ThreadSafeDictionary<Type, MethodInfo>();
-                
+
         public static Delegate CreateGetInstanceDelegate(this Type serviceType, IServiceFactory serviceFactory)
         {
             Type delegateType = serviceType.GetFuncType();
@@ -1460,20 +1462,20 @@ namespace LightInject
     }
 
     internal static class NamedDelegateTypeExtensions
-    {        
+    {
         private static readonly MethodInfo CreateInstanceDelegateMethodInfo =
             typeof(NamedDelegateTypeExtensions).GetPrivateStaticMethod("CreateInstanceDelegate");
 
         private static readonly ThreadSafeDictionary<Type, MethodInfo> CreateInstanceDelegateMethods =
             new ThreadSafeDictionary<Type, MethodInfo>();
-       
+
         public static Delegate CreateNamedGetInstanceDelegate(this Type serviceType, string serviceName, IServiceFactory factory)
-        {                        
+        {
             MethodInfo createInstanceDelegateMethodInfo = CreateInstanceDelegateMethods.GetOrAdd(
                 serviceType,
                 CreateClosedGenericCreateInstanceDelegateMethod);
 
-            return (Delegate)createInstanceDelegateMethodInfo.Invoke(null, new object[] { factory, serviceName });                        
+            return (Delegate)createInstanceDelegateMethodInfo.Invoke(null, new object[] { factory, serviceName });
         }
 
         private static MethodInfo CreateClosedGenericCreateInstanceDelegateMethod(Type type)
@@ -1490,19 +1492,19 @@ namespace LightInject
     }
 
     internal static class ReflectionHelper
-    {                                        
-        private static readonly Lazy<ThreadSafeDictionary<Type, MethodInfo>> GetInstanceWithParametersMethods;        
-        
+    {
+        private static readonly Lazy<ThreadSafeDictionary<Type, MethodInfo>> GetInstanceWithParametersMethods;
+
         static ReflectionHelper()
-        {                                    
-            GetInstanceWithParametersMethods = CreateLazyGetInstanceWithParametersMethods();            
+        {
+            GetInstanceWithParametersMethods = CreateLazyGetInstanceWithParametersMethods();
         }
-                               
+
         public static MethodInfo GetGetInstanceWithParametersMethod(Type serviceType)
         {
             return GetInstanceWithParametersMethods.Value.GetOrAdd(serviceType, CreateGetInstanceWithParametersMethod);
         }
-                                                     
+
         public static Delegate CreateGetNamedInstanceWithParametersDelegate(IServiceFactory factory, Type delegateType, string serviceName)
         {
             Type[] genericTypeArguments = delegateType.GetGenericTypeArguments();
@@ -1515,13 +1517,13 @@ namespace LightInject
             var closedGenericMethod = openGenericMethod.MakeGenericMethod(genericTypeArguments);
             return (Delegate)closedGenericMethod.Invoke(null, new object[] { factory, serviceName });
         }
-        
+
         private static Lazy<ThreadSafeDictionary<Type, MethodInfo>> CreateLazyGetInstanceWithParametersMethods()
         {
             return new Lazy<ThreadSafeDictionary<Type, MethodInfo>>(
                 () => new ThreadSafeDictionary<Type, MethodInfo>());
         }
-                                         
+
         private static MethodInfo CreateGetInstanceWithParametersMethod(Type serviceType)
         {
             Type[] genericTypeArguments = serviceType.GetGenericTypeArguments();
@@ -1533,7 +1535,7 @@ namespace LightInject
 
             return closedGenericMethod;
         }
-                                                                           
+
         // ReSharper disable UnusedMember.Local
         private static Func<TArg, TService> CreateGenericGetNamedParameterizedInstanceDelegate<TArg, TService>(IServiceFactory factory, string serviceName)
         // ReSharper restore UnusedMember.Local
@@ -1565,12 +1567,12 @@ namespace LightInject
 
     internal static class TypeHelper
     {
-#if NETFX_CORE || WINDOWS_PHONE || IOS       
+#if NETFX_CORE || WINDOWS_PHONE || IOS || DNXCORE50
         public static Type[] GetGenericTypeArguments(this Type type)
         {
             return type.GetTypeInfo().GenericTypeArguments;
         }
-       
+
         public static MethodInfo[] GetMethods(this Type type)
         {
             return type.GetTypeInfo().DeclaredMethods.ToArray();
@@ -1590,17 +1592,17 @@ namespace LightInject
         {
             return type.GetTypeInfo().DeclaredConstructors.Where(c => c.IsPublic && !c.IsStatic).ToArray();
         }
-        
+
         public static MethodInfo GetPrivateMethod(this Type type, string name)
-        {            
+        {
             return GetMethod(type, name);
         }
-        
+
         public static MethodInfo GetPrivateStaticMethod(this Type type, string name)
         {
             return GetMethod(type, name);
         }
-        
+
         public static MethodInfo[] GetPrivateStaticMethods(this Type type)
         {
             return type.GetRuntimeMethods().Where(m => m.IsPrivate && m.IsStatic).ToArray();
@@ -1672,7 +1674,7 @@ namespace LightInject
         }
 
         public static MethodInfo GetSetMethod(this PropertyInfo propertyInfo)
-        {                        
+        {
             return propertyInfo.SetMethod;
         }
 
@@ -1690,26 +1692,26 @@ namespace LightInject
         {
             return type.GetTypeInfo().Assembly;
         }
-        
+
         public static ConstructorInfo GetConstructor(this Type type, Type[] types)
         {
             return
                 GetConstructors(type).FirstOrDefault(c => c.GetParameters().Select(p => p.ParameterType).SequenceEqual(types));
-        }        
+        }
 #endif
-#if NET        
+#if NET
         public static Delegate CreateDelegate(this MethodInfo methodInfo, Type delegateType, object target)
         {
             return Delegate.CreateDelegate(delegateType, target, methodInfo);
         }
 
 #endif
-#if NET || NET45
+#if NET || NET45 || DNX451
         public static Type[] GetGenericTypeArguments(this Type type)
         {
             return type.GetGenericArguments();
-        }        
-        
+        }
+
         public static bool IsClass(this Type type)
         {
             return type.IsClass;
@@ -1744,7 +1746,7 @@ namespace LightInject
         {
             return type.IsGenericTypeDefinition;
         }
-   
+
         public static Assembly GetAssembly(this Type type)
         {
             return type.Assembly;
@@ -1753,7 +1755,7 @@ namespace LightInject
         public static bool IsValueType(this Type type)
         {
             return type.IsValueType;
-        }        
+        }
 
         public static MethodInfo GetMethodInfo(this Delegate del)
         {
@@ -1761,7 +1763,7 @@ namespace LightInject
         }
 
         public static MethodInfo GetPrivateMethod(this Type type, string name)
-        {            
+        {
             return type.GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
         }
 
@@ -1780,7 +1782,7 @@ namespace LightInject
             return assembly.GetCustomAttributes(attributeType, false).Cast<Attribute>();
         }
 #endif
-        
+
         public static bool IsEnumerableOfT(this Type serviceType)
         {
             return serviceType.IsGenericType() && serviceType.GetGenericTypeDefinition() == typeof(IEnumerable<>);
@@ -1795,8 +1797,8 @@ namespace LightInject
         {
             return serviceType.IsGenericType() && serviceType.GetGenericTypeDefinition() == typeof(ICollection<>);
         }
-#if NET45 || NETFX_CORE || WINDOWS_PHONE
-        
+#if NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
+
         public static bool IsReadOnlyCollectionOfT(this Type serviceType)
         {
             return serviceType.IsGenericType() && serviceType.GetGenericTypeDefinition() == typeof(IReadOnlyCollection<>);
@@ -1807,7 +1809,7 @@ namespace LightInject
             return serviceType.IsGenericType() && serviceType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>);
         }
 #endif
-        
+
         public static bool IsLazy(this Type serviceType)
         {
             return serviceType.IsGenericType() && serviceType.GetGenericTypeDefinition() == typeof(Lazy<>);
@@ -1835,26 +1837,26 @@ namespace LightInject
         {
             return serviceType.IsGenericType() && !serviceType.IsGenericTypeDefinition();
         }
-      
+
         public static Type GetElementType(Type type)
         {
             if (type.IsGenericType() && type.GetGenericTypeArguments().Count() == 1)
             {
                 return type.GetGenericTypeArguments()[0];
             }
-           
+
             return type.GetElementType();
         }
     }
 
     /// <summary>
-    /// Extends the <see cref="IEmitter"/> interface with a set of methods 
+    /// Extends the <see cref="IEmitter"/> interface with a set of methods
     /// that optimizes and simplifies emitting MSIL instructions.
     /// </summary>
     internal static class EmitterExtensions
     {
         /// <summary>
-        /// Performs a cast or unbox operation if the current <see cref="IEmitter.StackType"/> is 
+        /// Performs a cast or unbox operation if the current <see cref="IEmitter.StackType"/> is
         /// different from the given <paramref name="type"/>.
         /// </summary>
         /// <param name="emitter">The target <see cref="IEmitter"/>.</param>
@@ -1875,7 +1877,7 @@ namespace LightInject
         /// <param name="type">The requested stack type.</param>
         public static void PushConstant(this IEmitter emitter, int index, Type type)
         {
-            emitter.PushConstant(index);           
+            emitter.PushConstant(index);
             emitter.UnboxOrCast(type);
         }
 
@@ -1906,7 +1908,7 @@ namespace LightInject
         /// that is passed into the dynamic method.
         /// </summary>
         /// <param name="emitter">The target <see cref="IEmitter"/>.</param>
-        /// <param name="parameters">A list of <see cref="ParameterInfo"/> instances that 
+        /// <param name="parameters">A list of <see cref="ParameterInfo"/> instances that
         /// represent the arguments to be pushed onto the stack.</param>
         public static void PushArguments(this IEmitter emitter, ParameterInfo[] parameters)
         {
@@ -1931,7 +1933,7 @@ namespace LightInject
                     parameters[i].ParameterType);
             }
         }
-       
+
         /// <summary>
         /// Calls a late-bound method on an object, pushing the return value onto the stack.
         /// </summary>
@@ -1983,9 +1985,9 @@ namespace LightInject
             else
             {
                 emitter.Emit(OpCodes.Ldloc, index);
-            }                
+            }
         }
-        
+
         /// <summary>
         /// Pushes an argument with the given <paramref name="index"/> onto the stack.
         /// </summary>
@@ -2006,7 +2008,7 @@ namespace LightInject
                     return;
                 case 3:
                     emitter.Emit(OpCodes.Ldarg_3);
-                    return;                
+                    return;
             }
 
             if (index <= 255)
@@ -2016,7 +2018,7 @@ namespace LightInject
             else
             {
                 emitter.Emit(OpCodes.Ldarg, index);
-            }           
+            }
         }
 
         /// <summary>
@@ -2050,9 +2052,9 @@ namespace LightInject
             else
             {
                 emitter.Emit(OpCodes.Stloc, index);
-            }                                                    
+            }
         }
-        
+
         /// <summary>
         /// Pushes a new array of the given <paramref name="elementType"/> onto the stack.
         /// </summary>
@@ -2071,7 +2073,7 @@ namespace LightInject
         public static void Push(this IEmitter emitter, int value)
         {
             switch (value)
-            {                
+            {
                 case 0:
                     emitter.Emit(OpCodes.Ldc_I4_0);
                     return;
@@ -2151,13 +2153,13 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether variance is applied when resolving an <see cref="IEnumerable{T}"/>.        
+        /// Gets or sets a value indicating whether variance is applied when resolving an <see cref="IEnumerable{T}"/>.
         /// </summary>
         /// <remarks>
         /// The default value is true.
         /// </remarks>
         public bool EnableVariance { get; set; }
-        
+
         private static ContainerOptions CreateDefaultContainerOptions()
         {
             return new ContainerOptions { EnableVariance = true };
@@ -2168,9 +2170,9 @@ namespace LightInject
     /// An ultra lightweight service container.
     /// </summary>
     internal class ServiceContainer : IServiceContainer
-    {       
+    {
         private const string UnresolvedDependencyError = "Unresolved dependency {0}";
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         private readonly Func<Type, Type[], IMethodSkeleton> methodSkeletonFactory;
 #endif
 #if IOS
@@ -2180,7 +2182,7 @@ namespace LightInject
         private readonly ServiceRegistry<Expression> constructorDependencyFactories = new ServiceRegistry<Expression>();
         private readonly ServiceRegistry<Expression> propertyDependencyFactories = new ServiceRegistry<Expression>();
         private readonly ServiceRegistry<ServiceRegistration> availableServices = new ServiceRegistry<ServiceRegistration>();
-        
+
         private readonly object lockObject = new object();
         private readonly ContainerOptions options;
         private readonly Storage<object> constants = new Storage<object>();
@@ -2190,11 +2192,11 @@ namespace LightInject
         private readonly Storage<Initializer> initializers = new Storage<Initializer>();
 
         private readonly Stack<Action<IEmitter>> dependencyStack = new Stack<Action<IEmitter>>();
-                        
+
         private readonly Lazy<IConstructionInfoProvider> constructionInfoProvider;
         private readonly ICompositionRootExecutor compositionRootExecutor;
         private readonly ITypeExtractor compositionRootTypeExtractor;
-        
+
         private ImmutableHashTable<Type, GetInstanceDelegate> delegates =
             ImmutableHashTable<Type, GetInstanceDelegate>.Empty;
 
@@ -2205,7 +2207,7 @@ namespace LightInject
             ImmutableHashTree<Type, Func<object[], object, object>>.Empty;
 
         private bool isLocked;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceContainer"/> class.
         /// </summary>
@@ -2220,16 +2222,16 @@ namespace LightInject
             ConstructorDependencySelector = new ConstructorDependencySelector();
             ConstructorSelector = new MostResolvableConstructorSelector(CanGetInstance);
             constructionInfoProvider = new Lazy<IConstructionInfoProvider>(CreateConstructionInfoProvider);
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
             methodSkeletonFactory = (returnType, parameterTypes) => new DynamicMethodSkeleton(returnType, parameterTypes);
 #endif
 #if IOS
             methodSkeletonFactory = parameterTypes => new DynamicMethodSkeleton(parameterTypes);
 #endif
             ScopeManagerProvider = new PerThreadScopeManagerProvider();
-#if NET || NET45      
-            AssemblyLoader = new AssemblyLoader();            
-#endif            
+#if NET || NET45 || DNX451
+            AssemblyLoader = new AssemblyLoader();
+#endif
         }
 
         /// <summary>
@@ -2242,25 +2244,25 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="IScopeManagerProvider"/> that is responsible 
+        /// Gets or sets the <see cref="IScopeManagerProvider"/> that is responsible
         /// for providing the <see cref="ScopeManager"/> used to manage scopes.
         /// </summary>
         public IScopeManagerProvider ScopeManagerProvider { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IPropertyDependencySelector"/> instance that 
+        /// Gets or sets the <see cref="IPropertyDependencySelector"/> instance that
         /// is responsible for selecting the property dependencies for a given type.
         /// </summary>
         public IPropertyDependencySelector PropertyDependencySelector { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IConstructorDependencySelector"/> instance that 
+        /// Gets or sets the <see cref="IConstructorDependencySelector"/> instance that
         /// is responsible for selecting the constructor dependencies for a given constructor.
         /// </summary>
         public IConstructorDependencySelector ConstructorDependencySelector { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IConstructorSelector"/> instance that is responsible 
+        /// Gets or sets the <see cref="IConstructorSelector"/> instance that is responsible
         /// for selecting the constructor to be used when creating new service instances.
         /// </summary>
         public IConstructorSelector ConstructorSelector { get; set; }
@@ -2269,22 +2271,22 @@ namespace LightInject
         /// Gets or sets the <see cref="IAssemblyScanner"/> instance that is responsible for scanning assemblies.
         /// </summary>
         public IAssemblyScanner AssemblyScanner { get; set; }
-#if NET || NET45 
+#if NET || NET45 || DNX451
 
         /// <summary>
-        /// Gets or sets the <see cref="IAssemblyLoader"/> instance that is responsible for loading assemblies during assembly scanning. 
+        /// Gets or sets the <see cref="IAssemblyLoader"/> instance that is responsible for loading assemblies during assembly scanning.
         /// </summary>
         public IAssemblyLoader AssemblyLoader { get; set; }
 #endif
 
         /// <summary>
-        /// Gets a list of <see cref="ServiceRegistration"/> instances that represents the registered services.           
-        /// </summary>                  
+        /// Gets a list of <see cref="ServiceRegistration"/> instances that represents the registered services.
+        /// </summary>
         public IEnumerable<ServiceRegistration> AvailableServices
         {
             get
             {
-                return availableServices.Values.SelectMany(t => t.Values);                
+                return availableServices.Values.SelectMany(t => t.Values);
             }
         }
 
@@ -2323,7 +2325,7 @@ namespace LightInject
         /// <param name="instance">The target instance for which to inject its property dependencies.</param>
         /// <returns>The <paramref name="instance"/> with its property dependencies injected.</returns>
         public object InjectProperties(object instance)
-        {            
+        {
             var type = instance.GetType();
 
             var del = propertyInjectionDelegates.Search(type);
@@ -2334,18 +2336,18 @@ namespace LightInject
                 propertyInjectionDelegates = propertyInjectionDelegates.Add(type, del);
             }
 
-            return del(constants.Items, instance);            
+            return del(constants.Items, instance);
         }
 
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
-        /// <param name="serviceName">The name of the service.</param>        
+        /// <param name="serviceName">The name of the service.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<TService>(Expression<Func<IServiceFactory, TService>> factory, string serviceName, ILifetime lifetime)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, lifetime, serviceName);
@@ -2386,23 +2388,23 @@ namespace LightInject
         /// </summary>
         /// <param name="serviceRegistration">The <see cref="ServiceRegistration"/> instance that contains service metadata.</param>
         public void Register(ServiceRegistration serviceRegistration)
-        {            
-            var services = GetAvailableServices(serviceRegistration.ServiceType);            
+        {
+            var services = GetAvailableServices(serviceRegistration.ServiceType);
             var sr = serviceRegistration;
             services.AddOrUpdate(
                 serviceRegistration.ServiceName,
                 s => AddServiceRegistration(sr),
-                (k, existing) => UpdateServiceRegistration(existing, sr));            
+                (k, existing) => UpdateServiceRegistration(existing, sr));
         }
-      
+
         /// <summary>
         /// Registers composition roots from the given <paramref name="assembly"/>.
         /// </summary>
-        /// <param name="assembly">The assembly to be scanned for services.</param>        
+        /// <param name="assembly">The assembly to be scanned for services.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>             
+        /// </remarks>
         public void RegisterAssembly(Assembly assembly)
         {
             Type[] compositionRootTypes = compositionRootTypeExtractor.Execute(assembly);
@@ -2413,7 +2415,7 @@ namespace LightInject
             else
             {
                 AssemblyScanner.Scan(assembly, this);
-            }    
+            }
         }
 
         /// <summary>
@@ -2422,9 +2424,9 @@ namespace LightInject
         /// <param name="assembly">The assembly to be scanned for services.</param>
         /// <param name="shouldRegister">A function delegate that determines if a service implementation should be registered.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         public void RegisterAssembly(Assembly assembly, Func<Type, Type, bool> shouldRegister)
         {
             AssemblyScanner.Scan(assembly, this, () => null, shouldRegister);
@@ -2436,9 +2438,9 @@ namespace LightInject
         /// <param name="assembly">The assembly to be scanned for services.</param>
         /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of the registered service.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         public void RegisterAssembly(Assembly assembly, Func<ILifetime> lifetimeFactory)
         {
             AssemblyScanner.Scan(assembly, this, lifetimeFactory, (serviceType, implementingType) => true);
@@ -2451,9 +2453,9 @@ namespace LightInject
         /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of the registered service.</param>
         /// <param name="shouldRegister">A function delegate that determines if a service implementation should be registered.</param>
         /// <remarks>
-        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this 
+        /// If the target <paramref name="assembly"/> contains an implementation of the <see cref="ICompositionRoot"/> interface, this
         /// will be used to configure the container.
-        /// </remarks>     
+        /// </remarks>
         public void RegisterAssembly(Assembly assembly, Func<ILifetime> lifetimeFactory, Func<Type, Type, bool> shouldRegister)
         {
             AssemblyScanner.Scan(assembly, this, lifetimeFactory, shouldRegister);
@@ -2469,7 +2471,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Registers a factory delegate to be used when resolving a constructor dependency for 
+        /// Registers a factory delegate to be used when resolving a constructor dependency for
         /// a implicitly registered service.
         /// </summary>
         /// <typeparam name="TDependency">The dependency type.</typeparam>
@@ -2483,7 +2485,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Registers a factory delegate to be used when resolving a constructor dependency for 
+        /// Registers a factory delegate to be used when resolving a constructor dependency for
         /// a implicitly registered service.
         /// </summary>
         /// <typeparam name="TDependency">The dependency type.</typeparam>
@@ -2496,7 +2498,7 @@ namespace LightInject
                 (s, e) => isLocked ? e : factory);
         }
 
-#if NET || NET45 
+#if NET || NET45 || DNX451
         /// <summary>
         /// Registers composition roots from assemblies in the base directory that matches the <paramref name="searchPattern"/>.
         /// </summary>
@@ -2504,11 +2506,11 @@ namespace LightInject
         public void RegisterAssembly(string searchPattern)
         {
             foreach (Assembly assembly in AssemblyLoader.Load(searchPattern))
-            {                
-                RegisterAssembly(assembly);               
+            {
+                RegisterAssembly(assembly);
             }
-        }    
-    
+        }
+
 #endif
         /// <summary>
         /// Decorates the <paramref name="serviceType"/> with the given <paramref name="decoratorType"/>.
@@ -2527,7 +2529,7 @@ namespace LightInject
         /// Decorates the <paramref name="serviceType"/> with the given <paramref name="decoratorType"/>.
         /// </summary>
         /// <param name="serviceType">The target service type.</param>
-        /// <param name="decoratorType">The decorator type used to decorate the <paramref name="serviceType"/>.</param>        
+        /// <param name="decoratorType">The decorator type used to decorate the <paramref name="serviceType"/>.</param>
         public void Decorate(Type serviceType, Type decoratorType)
         {
             Decorate(serviceType, decoratorType, si => true);
@@ -2548,11 +2550,11 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="TService">The target service type.</typeparam>
         /// <param name="factory">A factory delegate used to create a decorator instance.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Decorate<TService>(Expression<Func<IServiceFactory, TService, TService>> factory)
         {
             var decoratorRegistration = new DecoratorRegistration { FactoryExpression = factory, ServiceType = typeof(TService), CanDecorate = si => true };
-            Decorate(decoratorRegistration);            
+            Decorate(decoratorRegistration);
         }
 
 #endif
@@ -2571,7 +2573,7 @@ namespace LightInject
         public void Decorate(DecoratorRegistration decoratorRegistration)
         {
             int index = decorators.Add(decoratorRegistration);
-            decoratorRegistration.Index = index;            
+            decoratorRegistration.Index = index;
         }
 
         /// <summary>
@@ -2592,7 +2594,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Allows post-processing of a service instance. 
+        /// Allows post-processing of a service instance.
         /// </summary>
         /// <param name="predicate">A function delegate that determines if the given service can be post-processed.</param>
         /// <param name="processor">An action delegate that exposes the created service instance.</param>
@@ -2667,15 +2669,15 @@ namespace LightInject
         {
             Register(typeof(TService), typeof(TImplementation), serviceName, lifetime);
         }
-       
+
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
         /// <param name="lifetime">The <see cref="ILifetime"/> instance that controls the lifetime of the registered service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<TService>(Expression<Func<IServiceFactory, TService>> factory, ILifetime lifetime)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, lifetime, string.Empty);
@@ -2691,13 +2693,13 @@ namespace LightInject
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
-        /// <param name="serviceName">The name of the service.</param>        
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <param name="serviceName">The name of the service.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<TService>(Expression<Func<IServiceFactory, TService>> factory, string serviceName)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, serviceName);
@@ -2751,7 +2753,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>. 
+        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="instance">The instance returned when this service is requested.</param>
@@ -2762,7 +2764,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>. 
+        /// Registers the <typeparamref name="TService"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
         /// <param name="instance">The instance returned when this service is requested.</param>
@@ -2772,7 +2774,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>. 
+        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <param name="serviceType">The service type to register.</param>
         /// <param name="instance">The instance returned when this service is requested.</param>
@@ -2780,9 +2782,9 @@ namespace LightInject
         {
             RegisterInstance(serviceType, instance, string.Empty);
         }
-       
+
         /// <summary>
-        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>. 
+        /// Registers the <paramref name="serviceType"/> with the given <paramref name="instance"/>.
         /// </summary>
         /// <param name="serviceType">The service type to register.</param>
         /// <param name="instance">The instance returned when this service is requested.</param>
@@ -2796,12 +2798,12 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="TService">The service type to register.</typeparam>
-        /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>       
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <param name="factory">The lambdaExpression that describes the dependencies of the service.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<TService>(Expression<Func<IServiceFactory, TService>> factory)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, string.Empty);
@@ -2817,13 +2819,13 @@ namespace LightInject
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T">The parameter type.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T, TService>(Expression<Func<IServiceFactory, T, TService>> factory)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, string.Empty);
@@ -2839,14 +2841,14 @@ namespace LightInject
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T">The parameter type.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param> 
-        /// <param name="serviceName">The name of the service.</param>        
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+        /// <param name="serviceName">The name of the service.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T, TService>(Expression<Func<IServiceFactory, T, TService>> factory, string serviceName)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, serviceName);
@@ -2862,14 +2864,14 @@ namespace LightInject
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE 
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T1, T2, TService>(Expression<Func<IServiceFactory, T1, T2, TService>> factory)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, string.Empty);
@@ -2883,17 +2885,17 @@ namespace LightInject
             RegisterFactoryDelegate(factoryDelegate, typeof(TService));
         }
 
-#endif        
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
         /// <param name="serviceName">The name of the service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T1, T2, TService>(Expression<Func<IServiceFactory, T1, T2, TService>> factory, string serviceName)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, serviceName);
@@ -2907,17 +2909,17 @@ namespace LightInject
             RegisterFactoryDelegate(factoryDelegate, typeof(TService), serviceName);
         }
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T1, T2, T3, TService>(Expression<Func<IServiceFactory, T1, T2, T3, TService>> factory)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, string.Empty);
@@ -2931,18 +2933,18 @@ namespace LightInject
             RegisterFactoryDelegate(factoryDelegate, typeof(TService));
         }
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
         /// <param name="serviceName">The name of the service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T1, T2, T3, TService>(Expression<Func<IServiceFactory, T1, T2, T3, TService>> factory, string serviceName)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, serviceName);
@@ -2956,18 +2958,18 @@ namespace LightInject
             RegisterFactoryDelegate(factoryDelegate, typeof(TService), serviceName);
         }
 
-#endif 
+#endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T1, T2, T3, T4, TService>(Expression<Func<IServiceFactory, T1, T2, T3, T4, TService>> factory)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, string.Empty);
@@ -2983,17 +2985,17 @@ namespace LightInject
 
 #endif
         /// <summary>
-        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that 
-        /// describes the dependencies of the service. 
+        /// Registers the <typeparamref name="TService"/> with the <paramref name="factory"/> that
+        /// describes the dependencies of the service.
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The service type to register.</typeparam>        
-        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>    
+        /// <typeparam name="TService">The service type to register.</typeparam>
+        /// <param name="factory">A factory delegate used to create the <typeparamref name="TService"/> instance.</param>
         /// <param name="serviceName">The name of the service.</param>
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         public void Register<T1, T2, T3, T4, TService>(Expression<Func<IServiceFactory, T1, T2, T3, T4, TService>> factory, string serviceName)
         {
             RegisterServiceFromLambdaExpression<TService>(factory, null, serviceName);
@@ -3007,7 +3009,7 @@ namespace LightInject
             RegisterFactoryDelegate(factoryDelegate, typeof(TService), serviceName);
         }
 
-#endif 
+#endif
         /// <summary>
         /// Registers the <paramref name="serviceType"/> with the <paramref name="implementingType"/>.
         /// </summary>
@@ -3025,7 +3027,7 @@ namespace LightInject
         /// <param name="serviceType">The service type to register.</param>
         /// <param name="implementingType">The implementing type.</param>
         public void Register(Type serviceType, Type implementingType)
-        {            
+        {
             RegisterService(serviceType, implementingType, null, string.Empty);
         }
 
@@ -3042,7 +3044,7 @@ namespace LightInject
                 instanceDelegate = CreateDefaultDelegate(serviceType, throwError: true);
             }
 
-            return instanceDelegate(constants.Items);            
+            return instanceDelegate(constants.Items);
         }
 
         /// <summary>
@@ -3061,7 +3063,7 @@ namespace LightInject
 
             object[] constantsWithArguments = constants.Items.Concat(new object[] { arguments }).ToArray();
 
-            return instanceDelegate(constantsWithArguments);                         
+            return instanceDelegate(constantsWithArguments);
         }
 
         /// <summary>
@@ -3069,7 +3071,7 @@ namespace LightInject
         /// </summary>
         /// <param name="serviceType">The type of the requested service.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <param name="arguments">The arguments to be passed to the target instance.</param>        
+        /// <param name="arguments">The arguments to be passed to the target instance.</param>
         /// <returns>The requested service instance.</returns>
         public object GetInstance(Type serviceType, string serviceName, object[] arguments)
         {
@@ -3079,10 +3081,10 @@ namespace LightInject
             {
                 instanceDelegate = CreateNamedDelegate(key, throwError: true);
             }
-            
+
             object[] constantsWithArguments = constants.Items.Concat(new object[] { arguments }).ToArray();
 
-            return instanceDelegate(constantsWithArguments);                                    
+            return instanceDelegate(constantsWithArguments);
         }
 
         /// <summary>
@@ -3100,7 +3102,7 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<TService>(string serviceName)
         {
             return (TService)GetInstance(typeof(TService), serviceName);
@@ -3110,9 +3112,9 @@ namespace LightInject
         /// Gets an instance of the given <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="T">The type of the argument.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="value">The argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T, TService>(T value)
         {
             return (TService)GetInstance(typeof(TService), new object[] { value });
@@ -3122,10 +3124,10 @@ namespace LightInject
         /// Gets an instance of the given <typeparamref name="TService"/>.
         /// </summary>
         /// <typeparam name="T">The type of the parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="value">The argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T, TService>(T value, string serviceName)
         {
             return (TService)GetInstance(typeof(TService), serviceName, new object[] { value });
@@ -3136,10 +3138,10 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T1, T2, TService>(T1 arg1, T2 arg2)
         {
             return (TService)GetInstance(typeof(TService), new object[] { arg1, arg2 });
@@ -3150,11 +3152,11 @@ namespace LightInject
         /// </summary>
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T1, T2, TService>(T1 arg1, T2 arg2, string serviceName)
         {
             return (TService)GetInstance(typeof(TService), serviceName, new object[] { arg1, arg2 });
@@ -3166,11 +3168,11 @@ namespace LightInject
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T1, T2, T3, TService>(T1 arg1, T2 arg2, T3 arg3)
         {
             return (TService)GetInstance(typeof(TService), new object[] { arg1, arg2, arg3 });
@@ -3182,12 +3184,12 @@ namespace LightInject
         /// <typeparam name="T1">The type of the first parameter.</typeparam>
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T1, T2, T3, TService>(T1 arg1, T2 arg2, T3 arg3, string serviceName)
         {
             return (TService)GetInstance(typeof(TService), serviceName, new object[] { arg1, arg2, arg3 });
@@ -3200,12 +3202,12 @@ namespace LightInject
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
         /// <param name="arg4">The fourth argument value.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T1, T2, T3, T4, TService>(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             return (TService)GetInstance(typeof(TService), new object[] { arg1, arg2, arg3, arg4 });
@@ -3218,13 +3220,13 @@ namespace LightInject
         /// <typeparam name="T2">The type of the second parameter.</typeparam>
         /// <typeparam name="T3">The type of the third parameter.</typeparam>
         /// <typeparam name="T4">The type of the fourth parameter.</typeparam>
-        /// <typeparam name="TService">The type of the requested service.</typeparam>        
+        /// <typeparam name="TService">The type of the requested service.</typeparam>
         /// <param name="arg1">The first argument value.</param>
         /// <param name="arg2">The second argument value.</param>
         /// <param name="arg3">The third argument value.</param>
         /// <param name="arg4">The fourth argument value.</param>
         /// <param name="serviceName">The name of the requested service.</param>
-        /// <returns>The requested service instance.</returns>    
+        /// <returns>The requested service instance.</returns>
         public TService GetInstance<T1, T2, T3, T4, TService>(T1 arg1, T2 arg2, T3 arg3, T4 arg4, string serviceName)
         {
             return (TService)GetInstance(typeof(TService), serviceName, new object[] { arg1, arg2, arg3, arg4 });
@@ -3243,7 +3245,7 @@ namespace LightInject
                 instanceDelegate = CreateDefaultDelegate(serviceType, throwError: false);
             }
 
-            return instanceDelegate(constants.Items); 
+            return instanceDelegate(constants.Items);
         }
 
         /// <summary>
@@ -3261,7 +3263,7 @@ namespace LightInject
                 instanceDelegate = CreateNamedDelegate(key, throwError: false);
             }
 
-            return instanceDelegate(constants.Items);       
+            return instanceDelegate(constants.Items);
         }
 
         /// <summary>
@@ -3300,7 +3302,7 @@ namespace LightInject
                 instanceDelegate = CreateNamedDelegate(key, throwError: true);
             }
 
-            return instanceDelegate(constants.Items);              
+            return instanceDelegate(constants.Items);
         }
 
         /// <summary>
@@ -3358,7 +3360,7 @@ namespace LightInject
             foreach (var disposableLifetimeInstance in disposableLifetimeInstances)
             {
                 disposableLifetimeInstance.Dispose();
-            }            
+            }
         }
 
         /// <summary>
@@ -3377,22 +3379,22 @@ namespace LightInject
         private static void EmitNewArray(IList<Action<IEmitter>> emitMethods, Type elementType, IEmitter emitter)
         {
             LocalBuilder array = emitter.DeclareLocal(elementType.MakeArrayType());
-            emitter.Push(emitMethods.Count);            
+            emitter.Push(emitMethods.Count);
             emitter.PushNewArray(elementType);
-            emitter.Store(array);            
+            emitter.Store(array);
 
             for (int index = 0; index < emitMethods.Count; index++)
-            {                
+            {
                 emitter.Push(array);
                 emitter.Push(index);
-                emitMethods[index](emitter);                
-                emitter.UnboxOrCast(elementType);                                    
+                emitMethods[index](emitter);
+                emitter.UnboxOrCast(elementType);
                 emitter.Emit(OpCodes.Stelem, elementType);
             }
 
             emitter.Push(array);
         }
-        
+
         private static ILifetime CloneLifeTime(ILifetime lifetime)
         {
             return lifetime == null ? null : (ILifetime)Activator.CreateInstance(lifetime.GetType());
@@ -3416,7 +3418,7 @@ namespace LightInject
             Type implementingType = openGenericDecorator.ImplementingType;
             Type[] genericTypeArguments = serviceRegistration.ServiceType.GetGenericTypeArguments();
             Type closedGenericDecoratorType = implementingType.MakeGenericType(genericTypeArguments);
-                               
+
             var decoratorInfo = new DecoratorRegistration
             {
                 ServiceType = serviceRegistration.ServiceType,
@@ -3438,26 +3440,26 @@ namespace LightInject
                 return null;
             }
         }
-       
+
         private void EmitEnumerable(IList<Action<IEmitter>> serviceEmitters, Type elementType, IEmitter emitter)
         {
-            EmitNewArray(serviceEmitters, elementType, emitter);                       
+            EmitNewArray(serviceEmitters, elementType, emitter);
         }
 
         private Func<object[], object, object> CreatePropertyInjectionDelegate(Type concreteType)
         {
             lock (lockObject)
             {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
                 IMethodSkeleton methodSkeleton = methodSkeletonFactory(typeof(object), new[] { typeof(object[]), typeof(object) });
 #endif
 #if IOS
                 IMethodSkeleton methodSkeleton = methodSkeletonFactory(new[] { typeof(object[]), typeof(object) });
 #endif
-                ConstructionInfo constructionInfo = GetContructionInfoForConcreteType(concreteType);                
+                ConstructionInfo constructionInfo = GetContructionInfoForConcreteType(concreteType);
                 var emitter = methodSkeleton.GetEmitter();
                 emitter.PushArgument(1);
-                emitter.Cast(concreteType);                
+                emitter.Cast(concreteType);
                 try
                 {
                     EmitPropertyDependencies(constructionInfo, emitter);
@@ -3472,20 +3474,20 @@ namespace LightInject
 
                 isLocked = true;
 
-                return (Func<object[], object, object>)methodSkeleton.CreateDelegate(typeof(Func<object[], object, object>));                                        
-            }            
+                return (Func<object[], object, object>)methodSkeleton.CreateDelegate(typeof(Func<object[], object, object>));
+            }
         }
 
         private ConstructionInfo GetContructionInfoForConcreteType(Type concreteType)
         {
-            var serviceRegistration = GetServiceRegistrationForConcreteType(concreteType);                        
+            var serviceRegistration = GetServiceRegistrationForConcreteType(concreteType);
             return GetConstructionInfo(serviceRegistration);
         }
 
         private ServiceRegistration GetServiceRegistrationForConcreteType(Type concreteType)
         {
-            var services = GetAvailableServices(concreteType);            
-            return services.GetOrAdd(string.Empty, s => CreateServiceRegistrationBasedOnConcreteType(concreteType));            
+            var services = GetAvailableServices(concreteType);
+            return services.GetOrAdd(string.Empty, s => CreateServiceRegistrationBasedOnConcreteType(concreteType));
         }
 
         private ServiceRegistration CreateServiceRegistrationBasedOnConcreteType(Type type)
@@ -3505,12 +3507,12 @@ namespace LightInject
             return new ConstructionInfoProvider(CreateConstructionInfoBuilder());
         }
 
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         private ConstructionInfoBuilder CreateConstructionInfoBuilder()
         {
             return new ConstructionInfoBuilder(() => new LambdaConstructionInfoBuilder(), CreateTypeConstructionInfoBuilder);
         }
-#endif 
+#endif
 #if IOS
         private ConstructionInfoBuilder CreateConstructionInfoBuilder()
         {
@@ -3544,7 +3546,7 @@ namespace LightInject
 
         private GetInstanceDelegate CreateDynamicMethodDelegate(Action<IEmitter> serviceEmitter)
         {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
             var methodSkeleton = methodSkeletonFactory(typeof(object), new[] { typeof(object[]) });
 #endif
 #if IOS
@@ -3568,16 +3570,16 @@ namespace LightInject
 
             isLocked = true;
 
-            return (GetInstanceDelegate)methodSkeleton.CreateDelegate(typeof(GetInstanceDelegate));                                    
+            return (GetInstanceDelegate)methodSkeleton.CreateDelegate(typeof(GetInstanceDelegate));
         }
 
         private Func<object> WrapAsFuncDelegate(GetInstanceDelegate instanceDelegate)
         {
             return () => instanceDelegate(constants.Items);
         }
-       
+
         private Action<IEmitter> GetEmitMethod(Type serviceType, string serviceName)
-        {           
+        {
             Action<IEmitter> emitMethod = GetRegisteredEmitMethod(serviceType, serviceName);
 
             if (emitMethod == null)
@@ -3587,8 +3589,8 @@ namespace LightInject
 
             if (emitMethod == null)
             {
-                AssemblyScanner.Scan(serviceType.GetAssembly(), this);                
-                emitMethod = GetRegisteredEmitMethod(serviceType, serviceName);                
+                AssemblyScanner.Scan(serviceType.GetAssembly(), this);
+                emitMethod = GetRegisteredEmitMethod(serviceType, serviceName);
             }
 
             if (emitMethod == null)
@@ -3657,11 +3659,11 @@ namespace LightInject
                 GetEmitMethods(serviceType).AddOrUpdate(serviceName, s => emitMethod, (s, m) => emitMethod);
             }
         }
-        
+
         private ServiceRegistration AddServiceRegistration(ServiceRegistration serviceRegistration)
         {
             var emitDelegate = ResolveEmitMethod(serviceRegistration);
-            GetEmitMethods(serviceRegistration.ServiceType).TryAdd(serviceRegistration.ServiceName, emitDelegate);                
+            GetEmitMethods(serviceRegistration.ServiceType).TryAdd(serviceRegistration.ServiceName, emitDelegate);
             return serviceRegistration;
         }
 
@@ -3673,10 +3675,10 @@ namespace LightInject
             }
 
             Invalidate();
-            Action<IEmitter> emitMethod = ResolveEmitMethod(newRegistration);            
-            
+            Action<IEmitter> emitMethod = ResolveEmitMethod(newRegistration);
+
             var serviceEmitters = GetEmitMethods(newRegistration.ServiceType);
-            serviceEmitters[newRegistration.ServiceName] = emitMethod;                                               
+            serviceEmitters[newRegistration.ServiceName] = emitMethod;
             return newRegistration;
         }
 
@@ -3687,7 +3689,7 @@ namespace LightInject
             {
                 serviceRegistration = serviceOverride.ServiceRegistrationFactory(this, serviceRegistration);
             }
-                                   
+
             var serviceDecorators = GetDecorators(serviceRegistration);
             if (serviceDecorators.Length > 0)
             {
@@ -3701,10 +3703,10 @@ namespace LightInject
 
         private DecoratorRegistration[] GetDecorators(ServiceRegistration serviceRegistration)
         {
-            var registeredDecorators = decorators.Items.Where(d => d.ServiceType == serviceRegistration.ServiceType).ToList();            
+            var registeredDecorators = decorators.Items.Where(d => d.ServiceType == serviceRegistration.ServiceType).ToList();
 
-            registeredDecorators.AddRange(GetOpenGenericDecoratorRegistrations(serviceRegistration));            
-            registeredDecorators.AddRange(GetDeferredDecoratorRegistrations(serviceRegistration));                      
+            registeredDecorators.AddRange(GetOpenGenericDecoratorRegistrations(serviceRegistration));
+            registeredDecorators.AddRange(GetDeferredDecoratorRegistrations(serviceRegistration));
             return registeredDecorators.OrderBy(d => d.Index).ToArray();
         }
 
@@ -3729,9 +3731,9 @@ namespace LightInject
             ServiceRegistration serviceRegistration)
         {
             var registrations = new List<DecoratorRegistration>();
-            
+
             var deferredDecorators =
-                decorators.Items.Where(ds => ds.CanDecorate(serviceRegistration) && ds.HasDeferredImplementingType);            
+                decorators.Items.Where(ds => ds.CanDecorate(serviceRegistration) && ds.HasDeferredImplementingType);
             foreach (var deferredDecorator in deferredDecorators)
             {
                 var decoratorRegistration = new DecoratorRegistration
@@ -3739,7 +3741,7 @@ namespace LightInject
                     ServiceType = serviceRegistration.ServiceType,
                     ImplementingType =
                         deferredDecorator.ImplementingTypeFactory(this, serviceRegistration),
-                    CanDecorate = sr => true, 
+                    CanDecorate = sr => true,
                     Index = deferredDecorator.Index
                 };
                 registrations.Add(decoratorRegistration);
@@ -3753,7 +3755,7 @@ namespace LightInject
             ConstructionInfo constructionInfo = GetConstructionInfo(decoratorRegistration);
             var constructorDependency = GetConstructorDependencyThatRepresentsDecoratorTarget(
                 decoratorRegistration, constructionInfo);
-                
+
             if (constructorDependency != null)
             {
                 constructorDependency.IsDecoratorTarget = true;
@@ -3775,8 +3777,8 @@ namespace LightInject
             var serviceFactoryIndex = constants.Add(this);
             Type funcType = factoryDelegate.GetType();
             emitter.PushConstant(factoryDelegateIndex, funcType);
-            emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));            
-            pushInstance(emitter);            
+            emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));
+            pushInstance(emitter);
             MethodInfo invokeMethod = funcType.GetMethod("Invoke");
             emitter.Emit(OpCodes.Callvirt, invokeMethod);
         }
@@ -3787,7 +3789,7 @@ namespace LightInject
             {
                 int index = constants.Add(serviceRegistration.Value);
                 Type serviceType = serviceRegistration.ServiceType;
-                emitter.PushConstant(index, serviceType);                
+                emitter.PushConstant(index, serviceType);
             }
             else
             {
@@ -3795,7 +3797,7 @@ namespace LightInject
 
                 if (constructionInfo.FactoryDelegate != null)
                 {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
                     EmitNewInstanceUsingFactoryDelegate(constructionInfo.FactoryDelegate, emitter);
 #endif
 #if IOS
@@ -3805,7 +3807,7 @@ namespace LightInject
                 else
                 {
                     EmitNewInstanceUsingImplementingType(emitter, constructionInfo, null);
-                }    
+                }
             }
 
             var processors = initializers.Items.Where(i => i.Predicate(serviceRegistration)).ToArray();
@@ -3818,14 +3820,14 @@ namespace LightInject
             emitter.Store(instanceVariable);
             foreach (var postProcessor in processors)
             {
-                Type delegateType = postProcessor.Initialize.GetType();               
+                Type delegateType = postProcessor.Initialize.GetType();
                 var delegateIndex = constants.Add(postProcessor.Initialize);
                 emitter.PushConstant(delegateIndex, delegateType);
                 var serviceFactoryIndex = constants.Add(this);
                 emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));
-                emitter.Push(instanceVariable);                
+                emitter.Push(instanceVariable);
                 MethodInfo invokeMethod = delegateType.GetMethod("Invoke");
-                emitter.Call(invokeMethod);                
+                emitter.Call(invokeMethod);
             }
 
             emitter.Push(instanceVariable);
@@ -3839,13 +3841,13 @@ namespace LightInject
                 {
                     continue;
                 }
-                
+
                 Action<IEmitter> currentDecoratorTargetEmitter = decoratorTargetEmitMethod;
-                DecoratorRegistration currentDecorator = decorator;                
+                DecoratorRegistration currentDecorator = decorator;
                 decoratorTargetEmitMethod = e => EmitNewDecoratorInstance(currentDecorator, e, currentDecoratorTargetEmitter);
             }
 
-            decoratorTargetEmitMethod(emitter);            
+            decoratorTargetEmitMethod(emitter);
         }
 
         private void EmitNewInstanceUsingImplementingType(IEmitter emitter, ConstructionInfo constructionInfo, Action<IEmitter> decoratorTargetEmitMethod)
@@ -3855,21 +3857,21 @@ namespace LightInject
             EmitPropertyDependencies(constructionInfo, emitter);
         }
 
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         private void EmitNewInstanceUsingFactoryDelegate(Delegate factoryDelegate, IEmitter emitter)
-        {                        
+        {
             var factoryDelegateIndex = constants.Add(factoryDelegate);
             var serviceFactoryIndex = constants.Add(this);
             Type funcType = factoryDelegate.GetType();
             emitter.PushConstant(factoryDelegateIndex, funcType);
-            emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));            
+            emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));
             if (factoryDelegate.GetMethodInfo().GetParameters().Length > 2)
             {
                 var parameters = factoryDelegate.GetMethodInfo().GetParameters().Skip(2).ToArray();
-                emitter.PushArguments(parameters);                
+                emitter.PushArguments(parameters);
             }
-                                   
-            MethodInfo invokeMethod = funcType.GetMethod("Invoke");            
+
+            MethodInfo invokeMethod = funcType.GetMethod("Invoke");
             emitter.Call(invokeMethod);
         }
 
@@ -3910,10 +3912,10 @@ namespace LightInject
                     EmitConstructorDependency(emitter, dependency);
                 }
                 else
-                {                    
+                {
                     if (dependency.ServiceType.IsLazy())
                     {
-                        Action<IEmitter> instanceEmitter = decoratorTargetEmitter;                        
+                        Action<IEmitter> instanceEmitter = decoratorTargetEmitter;
                         decoratorTargetEmitter = CreateEmitMethodBasedOnLazyServiceRequest(
                             dependency.ServiceType, t => CreateTypedInstanceDelegate(instanceEmitter, t));
                     }
@@ -3924,7 +3926,7 @@ namespace LightInject
         }
 
         private Delegate CreateTypedInstanceDelegate(Action<IEmitter> emitter, Type serviceType)
-        {                        
+        {
             var openGenericMethod = GetType().GetPrivateMethod("CreateGenericDynamicMethodDelegate");
             var closedGenericMethod = openGenericMethod.MakeGenericMethod(serviceType);
             var del = WrapAsFuncDelegate(CreateDynamicMethodDelegate(emitter));
@@ -3934,18 +3936,18 @@ namespace LightInject
         // ReSharper disable UnusedMember.Local
         private Func<T> CreateGenericDynamicMethodDelegate<T>(Func<object> del)
         // ReSharper restore UnusedMember.Local
-        {            
+        {
             return () => (T)del();
         }
-        
+
         private void EmitConstructorDependency(IEmitter emitter, Dependency dependency)
         {
             var emitMethod = GetEmitMethodForDependency(dependency);
-                        
+
             try
             {
-                emitMethod(emitter);                
-                emitter.UnboxOrCast(dependency.ServiceType);                                    
+                emitMethod(emitter);
+                emitter.UnboxOrCast(dependency.ServiceType);
             }
             catch (InvalidOperationException ex)
             {
@@ -3963,14 +3965,14 @@ namespace LightInject
             }
 
             emitter.Push(instanceVariable);
-            propertyDependencyEmitMethod(emitter);                
+            propertyDependencyEmitMethod(emitter);
             emitter.UnboxOrCast(propertyDependency.ServiceType);
             emitter.Call(propertyDependency.Property.GetSetMethod());
         }
 
         private Action<IEmitter> GetEmitMethodForDependency(Dependency dependency)
         {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
             if (dependency.FactoryExpression != null)
             {
                 return skeleton => EmitDependencyUsingFactoryExpression(skeleton, dependency);
@@ -3980,7 +3982,7 @@ namespace LightInject
             Action<IEmitter> emitter = GetEmitMethod(dependency.ServiceType, dependency.ServiceName);
             if (emitter == null)
             {
-                emitter = GetEmitMethod(dependency.ServiceType, dependency.Name);                
+                emitter = GetEmitMethod(dependency.ServiceType, dependency.Name);
                 if (emitter == null && dependency.IsRequired)
                 {
                     throw new InvalidOperationException(string.Format(UnresolvedDependencyError, dependency));
@@ -3989,20 +3991,20 @@ namespace LightInject
 
             return emitter;
         }
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE    
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
 
         private void EmitDependencyUsingFactoryExpression(IEmitter emitter, Dependency dependency)
         {
             var actions = new List<Action<IEmitter>>();
             var parameterExpressions = dependency.FactoryExpression.AsEnumerable().Where(e => e is ParameterExpression).Distinct().Cast<ParameterExpression>().ToList();
-           
+
             Expression factoryExpression = dependency.FactoryExpression;
 
             if (dependency.FactoryExpression.NodeType == ExpressionType.Lambda)
             {
                 factoryExpression = ((LambdaExpression)factoryExpression).Body;
             }
-           
+
             foreach (var parametersExpression in parameterExpressions)
             {
                 if (parametersExpression.Type == typeof(IServiceFactory))
@@ -4020,7 +4022,7 @@ namespace LightInject
                     actions.Add(e => e.PushConstant(constants.Add(((PropertyDependency)dependency).Property), typeof(PropertyInfo)));
                 }
             }
-            
+
             var lambda = Expression.Lambda(factoryExpression, parameterExpressions.ToArray()).Compile();
 
             MethodInfo methodInfo = lambda.GetType().GetMethod("Invoke");
@@ -4031,7 +4033,7 @@ namespace LightInject
             }
 
             emitter.Call(methodInfo);
-        }        
+        }
 #endif
 
         private void EmitPropertyDependencies(ConstructionInfo constructionInfo, IEmitter emitter)
@@ -4042,20 +4044,20 @@ namespace LightInject
             }
 
             LocalBuilder instanceVariable = emitter.DeclareLocal(constructionInfo.ImplementingType);
-            emitter.Store(instanceVariable);            
+            emitter.Store(instanceVariable);
             foreach (var propertyDependency in constructionInfo.PropertyDependencies)
             {
                 EmitPropertyDependency(emitter, propertyDependency, instanceVariable);
             }
 
-            emitter.Push(instanceVariable);            
+            emitter.Push(instanceVariable);
         }
 
         private Action<IEmitter> CreateEmitMethodForUnknownService(Type serviceType, string serviceName)
         {
             Action<IEmitter> emitter = null;
             if (serviceType.IsLazy())
-            {                
+            {
                 emitter = CreateEmitMethodBasedOnLazyServiceRequest(serviceType, t => t.CreateGetInstanceDelegate(this));
             }
             else if (serviceType.IsFuncWithParameters())
@@ -4074,11 +4076,11 @@ namespace LightInject
             {
                 emitter = CreateEmitMethodForArrayServiceRequest(serviceType);
             }
-#if NET45 || NETFX_CORE || WINDOWS_PHONE 
+#if NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
             else if (serviceType.IsReadOnlyCollectionOfT() || serviceType.IsReadOnlyListOfT())
             {
                 emitter = CreateEmitMethodForReadOnlyCollectionServiceRequest(serviceType);
-            }            
+            }
 #endif
             else if (serviceType.IsListOfT())
             {
@@ -4087,7 +4089,7 @@ namespace LightInject
             else if (serviceType.IsCollectionOfT())
             {
                 emitter = CreateEmitMethodForListServiceRequest(serviceType);
-            }     
+            }
             else if (CanRedirectRequestForDefaultServiceToSingleNamedService(serviceType, serviceName))
             {
                 emitter = CreateServiceEmitterBasedOnSingleNamedInstance(serviceType);
@@ -4101,9 +4103,9 @@ namespace LightInject
 
             return emitter;
         }
-        
+
         private Action<IEmitter> CreateEmitMethodBasedOnFuncServiceRequest(Type serviceType, string serviceName)
-        {            
+        {
             Delegate getInstanceDelegate;
             var returnType = serviceType.GetGenericTypeArguments().Single();
             if (string.IsNullOrEmpty(serviceName))
@@ -4111,14 +4113,14 @@ namespace LightInject
                 getInstanceDelegate = returnType.CreateGetInstanceDelegate(this);
             }
             else
-            {                
+            {
                 getInstanceDelegate = returnType.CreateNamedGetInstanceDelegate(serviceName, this);
-            }  
-                      
+            }
+
             var constantIndex = constants.Add(getInstanceDelegate);
-            return e => e.PushConstant(constantIndex, serviceType);            
+            return e => e.PushConstant(constantIndex, serviceType);
         }
-                      
+
         private Action<IEmitter> CreateEmitMethodBasedParameterizedFuncRequest(Type serviceType, string serviceName)
         {
             Delegate getInstanceDelegate;
@@ -4137,14 +4139,14 @@ namespace LightInject
             var constantIndex = constants.Add(getInstanceDelegate);
             return e => e.PushConstant(constantIndex, serviceType);
         }
-        
+
         private Delegate CreateGetInstanceWithParametersDelegate(Type serviceType)
         {
             var getInstanceMethod = ReflectionHelper.GetGetInstanceWithParametersMethod(serviceType);
             return getInstanceMethod.CreateDelegate(serviceType, this);
         }
 
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         private Action<IEmitter> CreateServiceEmitterBasedOnFactoryRule(FactoryRule rule, Type serviceType, string serviceName)
         {
             var serviceRegistration = new ServiceRegistration { ServiceType = serviceType, ServiceName = serviceName, Lifetime = CloneLifeTime(rule.LifeTime) };
@@ -4188,7 +4190,7 @@ namespace LightInject
         private Action<IEmitter> CreateEmitMethodForArrayServiceRequest(Type serviceType)
         {
             Action<IEmitter> enumerableEmitter = CreateEmitMethodForEnumerableServiceServiceRequest(serviceType);
-            return enumerableEmitter;            
+            return enumerableEmitter;
         }
 
         private Action<IEmitter> CreateEmitMethodForListServiceRequest(Type serviceType)
@@ -4204,8 +4206,8 @@ namespace LightInject
                 ms.Emit(OpCodes.Call, closedGenericToListMethod);
             };
         }
-#if NET45 || NETFX_CORE || WINDOWS_PHONE
-        
+#if NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
+
         private Action<IEmitter> CreateEmitMethodForReadOnlyCollectionServiceRequest(Type serviceType)
         {
             Type elementType = TypeHelper.GetElementType(serviceType);
@@ -4213,15 +4215,15 @@ namespace LightInject
             ConstructorInfo constructorInfo = closedGenericReadOnlyCollectionType.GetConstructors()[0];
 
             Action<IEmitter> listEmitMethod = CreateEmitMethodForListServiceRequest(serviceType);
-            
+
             return emitter =>
             {
                 listEmitMethod(emitter);
-                emitter.New(constructorInfo);                
+                emitter.New(constructorInfo);
             };
         }
 #endif
-        
+
         private void EnsureEmitMethodsForOpenGenericTypesAreCreated(Type actualServiceType)
         {
             var openGenericServiceType = actualServiceType.GetGenericTypeDefinition();
@@ -4233,7 +4235,7 @@ namespace LightInject
         }
 
         private Action<IEmitter> CreateEmitMethodBasedOnLazyServiceRequest(Type serviceType, Func<Type, Delegate> valueFactoryDelegate)
-        {            
+        {
             Type actualServiceType = serviceType.GetGenericTypeArguments()[0];
             Type funcType = actualServiceType.GetFuncType();
             ConstructorInfo lazyConstructor = actualServiceType.GetLazyConstructor();
@@ -4242,19 +4244,19 @@ namespace LightInject
 
             return emitter =>
                 {
-                    emitter.PushConstant(constantIndex, funcType);      
-                    emitter.New(lazyConstructor);                    
+                    emitter.PushConstant(constantIndex, funcType);
+                    emitter.New(lazyConstructor);
                 };
         }
-             
+
         private ServiceRegistration GetOpenGenericServiceRegistration(Type openGenericServiceType, string serviceName)
         {
             var services = GetAvailableServices(openGenericServiceType);
             if (services.Count == 0)
             {
                 return null;
-            } 
-           
+            }
+
             ServiceRegistration openGenericServiceRegistration;
             services.TryGetValue(serviceName, out openGenericServiceRegistration);
             if (openGenericServiceRegistration == null && string.IsNullOrEmpty(serviceName) && services.Count == 1)
@@ -4270,12 +4272,12 @@ namespace LightInject
             Type openGenericServiceType = closedGenericServiceType.GetGenericTypeDefinition();
             ServiceRegistration openGenericServiceRegistration =
                 GetOpenGenericServiceRegistration(openGenericServiceType, serviceName);
-           
+
             if (openGenericServiceRegistration == null)
             {
                 return null;
             }
-            
+
             Type[] closedGenericArguments = closedGenericServiceType.GetGenericTypeArguments();
 
             Type closedGenericImplementingType = TryMakeGenericType(
@@ -4297,9 +4299,9 @@ namespace LightInject
                                                                   CloneLifeTime(
                                                                       openGenericServiceRegistration
                                                                   .Lifetime)
-                                                          };            
+                                                          };
             Register(serviceRegistration);
-            return GetEmitMethod(serviceRegistration.ServiceType, serviceRegistration.ServiceName);            
+            return GetEmitMethod(serviceRegistration.ServiceType, serviceRegistration.ServiceName);
         }
 
         private Action<IEmitter> CreateEmitMethodForEnumerableServiceServiceRequest(Type serviceType)
@@ -4320,7 +4322,7 @@ namespace LightInject
             {
                 emitMethods = GetEmitMethods(actualServiceType).Values.ToList();
             }
-            
+
             if (dependencyStack.Count > 0 && emitMethods.Contains(dependencyStack.Peek()))
             {
                 emitMethods.Remove(dependencyStack.Peek());
@@ -4338,7 +4340,7 @@ namespace LightInject
         {
             return string.IsNullOrEmpty(serviceName) && GetEmitMethods(serviceType).Count == 1;
         }
-        
+
         private ConstructionInfo GetConstructionInfo(Registration registration)
         {
             return constructionInfoProvider.Value.GetConstructionInfo(registration);
@@ -4348,7 +4350,7 @@ namespace LightInject
         {
             return emitters.GetOrAdd(serviceType, s => new ThreadSafeDictionary<string, Action<IEmitter>>(StringComparer.CurrentCultureIgnoreCase));
         }
-       
+
         private ThreadSafeDictionary<string, ServiceRegistration> GetAvailableServices(Type serviceType)
         {
             return availableServices.GetOrAdd(serviceType, s => new ThreadSafeDictionary<string, ServiceRegistration>(StringComparer.CurrentCultureIgnoreCase));
@@ -4374,11 +4376,11 @@ namespace LightInject
             Ensure.IsNotNull(implementingType, "implementingType");
             Ensure.IsNotNull(serviceName, "serviceName");
             var serviceRegistration = new ServiceRegistration { ServiceType = serviceType, ImplementingType = implementingType, ServiceName = serviceName, Lifetime = lifetime };
-            Register(serviceRegistration);         
+            Register(serviceRegistration);
         }
-        
+
         private Action<IEmitter> ResolveEmitMethod(ServiceRegistration serviceRegistration)
-        {                    
+        {
             if (serviceRegistration.Lifetime == null)
             {
                 return methodSkeleton => EmitNewInstanceWithDecorators(serviceRegistration, methodSkeleton);
@@ -4386,16 +4388,16 @@ namespace LightInject
 
             return methodSkeleton => EmitLifetime(serviceRegistration, ms => EmitNewInstanceWithDecorators(serviceRegistration, ms), methodSkeleton);
         }
-        
+
         private void EmitLifetime(ServiceRegistration serviceRegistration, Action<IEmitter> emitMethod, IEmitter emitter)
         {
             if (serviceRegistration.Lifetime is PerContainerLifetime)
             {
                 Func<object> instanceDelegate =
-                    WrapAsFuncDelegate(CreateDynamicMethodDelegate(emitMethod));                        
+                    WrapAsFuncDelegate(CreateDynamicMethodDelegate(emitMethod));
                 var instance = serviceRegistration.Lifetime.GetInstance(instanceDelegate, null);
                 var instanceIndex = constants.Add(instance);
-                emitter.PushConstant(instanceIndex, instance.GetType());                
+                emitter.PushConstant(instanceIndex, instance.GetType());
             }
             else
             {
@@ -4411,7 +4413,7 @@ namespace LightInject
                 emitter.Call(getInstanceMethod);
             }
         }
-       
+
         private int CreateScopeManagerProviderIndex()
         {
             return constants.Add(ScopeManagerProvider);
@@ -4420,7 +4422,7 @@ namespace LightInject
         private int CreateInstanceDelegateIndex(Action<IEmitter> emitMethod)
         {
             return constants.Add(WrapAsFuncDelegate(CreateDynamicMethodDelegate(emitMethod)));
-        }                
+        }
 
         private int CreateLifetimeIndex(ILifetime lifetime)
         {
@@ -4452,7 +4454,7 @@ namespace LightInject
         }
 
         private GetInstanceDelegate CreateDelegate(Type serviceType, string serviceName, bool throwError)
-        {            
+        {
             lock (lockObject)
             {
                 var serviceEmitter = GetEmitMethod(serviceType, serviceName);
@@ -4466,7 +4468,7 @@ namespace LightInject
                 {
                     try
                     {
-                        return CreateDynamicMethodDelegate(serviceEmitter);                        
+                        return CreateDynamicMethodDelegate(serviceEmitter);
                     }
                     catch (InvalidOperationException ex)
                     {
@@ -4480,19 +4482,19 @@ namespace LightInject
                 return null;
             }
         }
-                    
+
         private void RegisterValue(Type serviceType, object value, string serviceName)
         {
             var serviceRegistration = new ServiceRegistration { ServiceType = serviceType, ServiceName = serviceName, Value = value, Lifetime = new PerContainerLifetime() };
-            Register(serviceRegistration);            
+            Register(serviceRegistration);
         }
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
 
         private void RegisterServiceFromLambdaExpression<TService>(
             LambdaExpression factory, ILifetime lifetime, string serviceName)
         {
             var serviceRegistration = new ServiceRegistration { ServiceType = typeof(TService), FactoryExpression = factory, ServiceName = serviceName, Lifetime = lifetime };
-            Register(serviceRegistration);            
+            Register(serviceRegistration);
         }
 #endif
 #if IOS
@@ -4515,7 +4517,7 @@ namespace LightInject
 #endif
 
         private class Storage<T>
-        {            
+        {
             public T[] Items = new T[0];
 
             private readonly object lockObject = new object();
@@ -4571,13 +4573,13 @@ namespace LightInject
         }
 
         private class DynamicMethodSkeleton : IMethodSkeleton
-        {            
+        {
             private IEmitter emitter;
             private DynamicMethod dynamicMethod;
 
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
             public DynamicMethodSkeleton(Type returnType, Type[] parameterTypes)
-            {         
+            {
                 CreateDynamicMethod(returnType, parameterTypes);
             }
 
@@ -4595,7 +4597,7 @@ namespace LightInject
             }
 
             public Delegate CreateDelegate(Type delegateType)
-            {                                                                       
+            {
                 return dynamicMethod.CreateDelegate(delegateType);
             }
 
@@ -4604,13 +4606,18 @@ namespace LightInject
             {
                 dynamicMethod = new DynamicMethod(parameterTypes);
                 emitter = new Emitter(dynamicMethod.GetILGenerator(), parameterTypes);
-            }    
+            }
 #endif
-#if NET || NET45
+#if NET || NET45 || DNX451 || DNXCORE50
             private void CreateDynamicMethod(Type returnType, Type[] parameterTypes)
             {
+#if NET
                 dynamicMethod = new DynamicMethod(
                     "DynamicMethod", returnType, parameterTypes, typeof(ServiceContainer).Module, true);
+#else
+                dynamicMethod = new DynamicMethod(
+                    "DynamicMethod", returnType, parameterTypes, typeof(ServiceContainer).GetTypeInfo().Module, true);
+#endif
                 emitter = new Emitter(dynamicMethod.GetILGenerator(), parameterTypes);
             }
 #endif
@@ -4626,7 +4633,7 @@ namespace LightInject
         private class ServiceRegistry<T> : ThreadSafeDictionary<Type, ThreadSafeDictionary<string, T>>
         {
         }
-        
+
         private class FactoryRule
         {
             public Func<Type, string, bool> CanCreateInstance { get; set; }
@@ -4669,7 +4676,7 @@ namespace LightInject
         }
     }
 
-#if NET45         
+#if NET45 || DNX451
     /// <summary>
     /// A <see cref="IScopeManagerProvider"/> that provides a <see cref="ScopeManager"/> per
     /// <see cref="CallContext"/>.
@@ -4678,19 +4685,19 @@ namespace LightInject
     {
         private readonly LogicalThreadStorage<ScopeManager> scopeManagers =
             new LogicalThreadStorage<ScopeManager>(() => new ScopeManager());
-                
+
         /// <summary>
         /// Returns the <see cref="ScopeManager"/> that is responsible for managing scopes.
         /// </summary>
         /// <returns>The <see cref="ScopeManager"/> that is responsible for managing scopes.</returns>
         public ScopeManager GetScopeManager()
         {
-            return scopeManagers.Value;                        
+            return scopeManagers.Value;
         }
     }
 
 #endif
-#if NET || NET45 || NETFX_CORE 
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE
     /// <summary>
     /// A thread safe dictionary.
     /// </summary>
@@ -4706,7 +4713,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ThreadSafeDictionary{TKey,TValue}"/> class using the 
+        /// Initializes a new instance of the <see cref="ThreadSafeDictionary{TKey,TValue}"/> class using the
         /// given <see cref="IEqualityComparer{T}"/>.
         /// </summary>
         /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys</param>
@@ -4716,7 +4723,7 @@ namespace LightInject
         }
     }
 
-#endif 
+#endif
 #if WINDOWS_PHONE || IOS
     /// <summary>
     /// A thread safe dictionary.
@@ -4727,9 +4734,9 @@ namespace LightInject
     {
         private readonly Dictionary<TKey, TValue> dictionary;
         private readonly object syncObject = new object();
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="ThreadSafeDictionary{TKey,TValue}"/> class. 
+        /// Initializes a new instance of the <see cref="ThreadSafeDictionary{TKey,TValue}"/> class.
         /// </summary>
         public ThreadSafeDictionary()
         {
@@ -4737,7 +4744,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ThreadSafeDictionary{TKey,TValue}"/> class using the 
+        /// Initializes a new instance of the <see cref="ThreadSafeDictionary{TKey,TValue}"/> class using the
         /// given <see cref="IEqualityComparer{T}"/>.
         /// </summary>
         /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys</param>
@@ -4745,7 +4752,7 @@ namespace LightInject
         {
             dictionary = new Dictionary<TKey, TValue>(comparer);
         }
-       
+
         /// <summary>
         /// Gets the number of key/value pairs contained in the <see cref="ThreadSafeDictionary{TKey,TValue}"/>.
         /// </summary>
@@ -4794,8 +4801,8 @@ namespace LightInject
                 lock (syncObject)
                 {
                     dictionary[key] = value;
-                }                    
-            }                
+                }
+            }
         }
 
         /// <summary>
@@ -4817,10 +4824,10 @@ namespace LightInject
 
                 return value;
             }
-        }    
-        
+        }
+
         /// <summary>
-        /// Uses the specified functions to add a key/value pair to the <see cref="ThreadSafeDictionary{TKey,TValue}"/> if the key does not already exist, 
+        /// Uses the specified functions to add a key/value pair to the <see cref="ThreadSafeDictionary{TKey,TValue}"/> if the key does not already exist,
         /// or to update a key/value pair in the <see cref="ThreadSafeDictionary{TKey,TValue}"/> if the key already exists.
         /// </summary>
         /// <param name="key">The key to be added or whose value should be updated</param>
@@ -4846,7 +4853,7 @@ namespace LightInject
         /// Attempts to get the value associated with the specified key from the <see cref="ThreadSafeDictionary{TKey,TValue}"/>.
         /// </summary>
         /// <param name="key">The key of the value to get.</param>
-        /// <param name="value">When this method returns, contains the object from the <see cref="ThreadSafeDictionary{TKey,TValue}"/> that has the specified key, 
+        /// <param name="value">When this method returns, contains the object from the <see cref="ThreadSafeDictionary{TKey,TValue}"/> that has the specified key,
         /// or the default value of <typeparamref name="TValue"/>, if the operation failed.</param>
         public void TryGetValue(TKey key, out TValue value)
         {
@@ -4861,19 +4868,19 @@ namespace LightInject
         /// </summary>
         /// <param name="key">The key of the element to remove and return.</param>
         /// <param name="value">When this method returns, contains the object removed from the <see cref="ThreadSafeDictionary{TKey,TValue}"/>.</param>
-        /// <returns>When this method returns, contains the object removed from the <see cref="ThreadSafeDictionary{TKey,TValue}"/>, 
+        /// <returns>When this method returns, contains the object removed from the <see cref="ThreadSafeDictionary{TKey,TValue}"/>,
         /// or the default value of the <typeparamref name="TValue"/> type if key does not exist.</returns>
         public bool TryRemove(TKey key, out TValue value)
         {
             lock (syncObject)
-            {                    
+            {
                 if (dictionary.TryGetValue(key, out value))
-                {                 
+                {
                     return true;
                 }
-                
+
                 value = default(TValue);
-                return false;                
+                return false;
             }
         }
 
@@ -4884,28 +4891,28 @@ namespace LightInject
         /// <param name="value">The value of the element to add.</param>
         /// <returns>true if the key/value pair was added to the <see cref="ThreadSafeDictionary{TKey,TValue}"/> successfully; false if the key already exists.</returns>
         public bool TryAdd(TKey key, TValue value)
-        {           
+        {
             lock (syncObject)
             {
                 if (dictionary.ContainsKey(key))
                 {
                     return false;
                 }
-              
+
                 dictionary.Add(key, value);
-                return true;              
+                return true;
             }
         }
 
         /// <summary>
         /// Removes all keys and values from the <see cref="ThreadSafeDictionary{TKey,TValue}"/>.
-        /// </summary>        
+        /// </summary>
         public void Clear()
         {
             lock (syncObject)
             {
-                dictionary.Clear();    
-            }                
+                dictionary.Clear();
+            }
         }
 
         /// <summary>
@@ -4925,16 +4932,16 @@ namespace LightInject
         /// </summary>
         /// <returns>An enumerator for the <see cref="ThreadSafeDictionary{TKey,TValue}"/></returns>
         IEnumerator IEnumerable.GetEnumerator()
-        {          
+        {
             return GetEnumerator();
         }
     }
-                
+
 #endif
 #if NETFX_CORE || WINDOWS_PHONE || SILVERLIGHT
     /// <summary>
     /// Defines and represents a dynamic method that can be compiled and executed.
-    /// </summary>    
+    /// </summary>
     internal class DynamicMethod
     {
         private readonly Type returnType;
@@ -4984,9 +4991,9 @@ namespace LightInject
 
             Expression[] arguments = new Expression[] { Expression.Constant(target) }.Concat(parameters.Cast<Expression>().Skip(1)).ToArray();
             var invokeExpression = Expression.Invoke(lambdaWithTargetParameter, arguments);
-            
+
             var lambda = Expression.Lambda(delegateType, invokeExpression, parameters.Skip(1));
-            return lambda.Compile();            
+            return lambda.Compile();
         }
 
         /// <summary>
@@ -5019,7 +5026,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Gets the current expression based the emitted <see cref="OpCodes"/>. 
+        /// Gets the current expression based the emitted <see cref="OpCodes"/>.
         /// </summary>
         public Expression CurrentExpression
         {
@@ -5049,7 +5056,7 @@ namespace LightInject
                 throw new NotSupportedException(code.ToString());
             }
         }
- 
+
         /// <summary>
         /// Puts the specified instruction onto the stream of instructions.
         /// </summary>
@@ -5060,7 +5067,7 @@ namespace LightInject
             {
                 stack.Push(parameters[0]);
             }
-            else if (code == OpCodes.Ldarg_1)      
+            else if (code == OpCodes.Ldarg_1)
             {
                 stack.Push(parameters[1]);
             }
@@ -5127,7 +5134,7 @@ namespace LightInject
             {
                 Expression array = stack.Pop();
                 stack.Push(Expression.ArrayLength(array));
-            }        
+            }
             else if (code == OpCodes.Conv_I4)
             {
                 stack.Push(Expression.Convert(stack.Pop(), typeof(int)));
@@ -5167,15 +5174,15 @@ namespace LightInject
             else if (code == OpCodes.Ldc_I4_8)
             {
                 stack.Push(Expression.Constant(8, typeof(int)));
-            }                                  
+            }
             else if (code == OpCodes.Sub)
             {
                 var right = stack.Pop();
-                var left = stack.Pop();                
-                stack.Push(Expression.Subtract(left, right));                
+                var left = stack.Pop();
+                stack.Push(Expression.Subtract(left, right));
             }
             else if (code == OpCodes.Ret)
-            {                
+            {
             }
             else
             {
@@ -5195,7 +5202,7 @@ namespace LightInject
                 Expression valueExpression = stack.Pop();
                 var assignExpression = Expression.Assign(localBuilder.Variable, valueExpression);
                 expressions.Add(assignExpression);
-            }            
+            }
             else if (code == OpCodes.Ldloc)
             {
                 stack.Push(localBuilder.Variable);
@@ -5230,7 +5237,7 @@ namespace LightInject
                 Expression valueExpression = stack.Pop();
                 var assignExpression = Expression.Assign(locals[arg].Variable, valueExpression);
                 expressions.Add(assignExpression);
-            }   
+            }
             else
             {
                 throw new NotSupportedException(code.ToString());
@@ -5247,11 +5254,11 @@ namespace LightInject
             if (code == OpCodes.Ldc_I4_S)
             {
                 stack.Push(Expression.Constant(arg, typeof(sbyte)));
-            }            
+            }
             else
             {
                 throw new NotSupportedException(code.ToString());
-            }            
+            }
         }
 
         /// <summary>
@@ -5278,7 +5285,7 @@ namespace LightInject
             else
             {
                 throw new NotSupportedException(code.ToString());
-            }            
+            }
         }
 
         /// <summary>
@@ -5320,14 +5327,14 @@ namespace LightInject
             if (code == OpCodes.Newarr)
             {
                 stack.Push(Expression.NewArrayBounds(type, Pop(1)));
-            }            
+            }
             else if (code == OpCodes.Stelem)
             {
                 var value = stack.Pop();
                 var index = stack.Pop();
-                var array = stack.Pop();                
+                var array = stack.Pop();
                 var arrayAccess = Expression.ArrayAccess(array, index);
-                
+
                 var assignExpression = Expression.Assign(arrayAccess, value);
                 expressions.Add(assignExpression);
             }
@@ -5346,7 +5353,7 @@ namespace LightInject
             else
             {
                 throw new NotSupportedException(code.ToString());
-            }            
+            }
         }
 
         /// <summary>
@@ -5366,21 +5373,21 @@ namespace LightInject
                 if (!methodInfo.IsStatic)
                 {
                     var instance = stack.Pop();
-                    methodCallExpression = Expression.Call(instance, methodInfo, arguments);    
+                    methodCallExpression = Expression.Call(instance, methodInfo, arguments);
                 }
                 else
                 {
                     methodCallExpression = Expression.Call(null, methodInfo, arguments);
                 }
-                
+
                 if (methodInfo.ReturnType == typeof(void))
                 {
                     expressions.Add(methodCallExpression);
                 }
                 else
                 {
-                    stack.Push(methodCallExpression);    
-                }                
+                    stack.Push(methodCallExpression);
+                }
             }
             else
             {
@@ -5410,7 +5417,7 @@ namespace LightInject
         /// Initializes a new instance of the <see cref="LocalBuilder"/> class.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> of the variable that this <see cref="LocalBuilder"/> represents.</param>
-        /// <param name="localIndex">The zero-based index of the local variable within the method body.</param> 
+        /// <param name="localIndex">The zero-based index of the local variable within the method body.</param>
         public LocalBuilder(Type type, int localIndex)
         {
             Variable = Expression.Parameter(type);
@@ -5421,29 +5428,29 @@ namespace LightInject
         /// <summary>
         /// Gets the <see cref="ParameterExpression"/> that represents the variable.
         /// </summary>
-        public ParameterExpression Variable { get; private set; }         
-        
+        public ParameterExpression Variable { get; private set; }
+
         /// <summary>
         /// Gets the type of the local variable.
         /// </summary>
         public Type LocalType { get; private set; }
-    
+
         /// <summary>
         /// Gets the zero-based index of the local variable within the method body.
         /// </summary>
         public int LocalIndex { get; private set; }
-    } 
-  
+    }
+
 #endif
 #if IOS
     internal class DynamicMethod
     {
-        
+
         private readonly Type[] parameterTypes;
         private readonly ILGenerator generator;
-        
+
         public DynamicMethod(Type[] parameterTypes)
-        {            
+        {
             this.parameterTypes = parameterTypes;
             generator = new ILGenerator();
         }
@@ -5452,7 +5459,7 @@ namespace LightInject
         {
             MethodInfo executeMethod;
             var parameterCount = parameterTypes.Length;
-            
+
             if (parameterCount == 1)
             {
                 executeMethod = typeof(ILGenerator).GetMethod("ExecuteUsingOneArgument");
@@ -5516,7 +5523,7 @@ namespace LightInject
 
             return context.Stack.Pop();
         }
-        
+
         public LocalBuilder DeclareLocal(Type type)
         {
             var localBuilder = new LocalBuilder(type, declaredLocals.Count);
@@ -5721,7 +5728,7 @@ namespace LightInject
             else if (code == OpCodes.Ldarg_1)
             {
                 stack.Push(args[1]);
-            }            
+            }
             else if (code == OpCodes.Ldloc_0)
             {
                 stack.Push(locals[0].Value);
@@ -5845,7 +5852,7 @@ namespace LightInject
         /// Initializes a new instance of the <see cref="LocalBuilder"/> class.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> of the variable that this <see cref="LocalBuilder"/> represents.</param>
-        /// <param name="localIndex">The zero-based index of the local variable within the method body.</param> 
+        /// <param name="localIndex">The zero-based index of the local variable within the method body.</param>
         public LocalBuilder(Type type, int localIndex)
         {
             LocalType = type;
@@ -5934,7 +5941,7 @@ namespace LightInject
         private bool CanCreateParameterDependency(ParameterInfo parameterInfo)
         {
             return canGetInstance(parameterInfo.ParameterType, string.Empty) || canGetInstance(parameterInfo.ParameterType, GetServiceName(parameterInfo));
-        }       
+        }
     }
 
     /// <summary>
@@ -5973,7 +5980,7 @@ namespace LightInject
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyDependencySelector"/> class.
         /// </summary>
-        /// <param name="propertySelector">The <see cref="IPropertySelector"/> that is 
+        /// <param name="propertySelector">The <see cref="IPropertySelector"/> that is
         /// responsible for selecting a list of injectable properties.</param>
         public PropertyDependencySelector(IPropertySelector propertySelector)
         {
@@ -5981,7 +5988,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Gets the <see cref="IPropertySelector"/> that is responsible for selecting a 
+        /// Gets the <see cref="IPropertySelector"/> that is responsible for selecting a
         /// list of injectable properties.
         /// </summary>
         protected IPropertySelector PropertySelector { get; private set; }
@@ -6016,7 +6023,7 @@ namespace LightInject
         /// </summary>
         /// <param name="constructorSelector">The <see cref="IConstructorSelector"/> that is responsible
         /// for selecting the constructor to be used for constructor injection.</param>
-        /// <param name="constructorDependencySelector">The <see cref="IConstructorDependencySelector"/> that is 
+        /// <param name="constructorDependencySelector">The <see cref="IConstructorDependencySelector"/> that is
         /// responsible for selecting the constructor dependencies for a given <see cref="ConstructionInfo"/>.</param>
         /// <param name="propertyDependencySelector">The <see cref="IPropertyDependencySelector"/> that is responsible
         /// for selecting the property dependencies for a given <see cref="Type"/>.</param>
@@ -6044,15 +6051,15 @@ namespace LightInject
         public ConstructionInfo Execute(Registration registration)
         {
             var implementingType = registration.ImplementingType;
-            var constructionInfo = new ConstructionInfo();            
+            var constructionInfo = new ConstructionInfo();
             constructionInfo.ImplementingType = implementingType;
             constructionInfo.PropertyDependencies.AddRange(GetPropertyDependencies(implementingType));
             if (!registration.IgnoreConstructorDependencies)
-            {                
+            {
                 constructionInfo.Constructor = constructorSelector.Execute(implementingType);
-                constructionInfo.ConstructorDependencies.AddRange(GetConstructorDependencies(constructionInfo.Constructor));    
-            }          
-  
+                constructionInfo.ConstructorDependencies.AddRange(GetConstructorDependencies(constructionInfo.Constructor));
+            }
+
             return constructionInfo;
         }
 
@@ -6096,7 +6103,7 @@ namespace LightInject
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstructionInfoProvider"/> class.
         /// </summary>
-        /// <param name="constructionInfoBuilder">The <see cref="IConstructionInfoBuilder"/> that 
+        /// <param name="constructionInfoBuilder">The <see cref="IConstructionInfoBuilder"/> that
         /// is responsible for building a <see cref="ConstructionInfo"/> instance based on a given <see cref="Registration"/>.</param>
         public ConstructionInfoProvider(IConstructionInfoBuilder constructionInfoBuilder)
         {
@@ -6114,7 +6121,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Invalidates the <see cref="IConstructionInfoProvider"/> and causes new <see cref="ConstructionInfo"/> instances 
+        /// Invalidates the <see cref="IConstructionInfoProvider"/> and causes new <see cref="ConstructionInfo"/> instances
         /// to be created when the <see cref="IConstructionInfoProvider.GetConstructionInfo"/> method is called.
         /// </summary>
         public void Invalidate()
@@ -6124,19 +6131,19 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Provides a <see cref="ConstructorInfo"/> instance 
+    /// Provides a <see cref="ConstructorInfo"/> instance
     /// that describes how to create a service instance.
     /// </summary>
     internal class ConstructionInfoBuilder : IConstructionInfoBuilder
     {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         private readonly Lazy<ILambdaConstructionInfoBuilder> lambdaConstructionInfoBuilder;
 #endif
         private readonly Lazy<ITypeConstructionInfoBuilder> typeConstructionInfoBuilder;
- 
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConstructionInfoBuilder"/> class.             
+        /// Initializes a new instance of the <see cref="ConstructionInfoBuilder"/> class.
         /// </summary>
         /// <param name="lambdaConstructionInfoBuilderFactory">
         /// A function delegate used to provide a <see cref="ILambdaConstructionInfoBuilder"/> instance.
@@ -6155,15 +6162,15 @@ namespace LightInject
 #endif
 #if IOS
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConstructionInfoBuilder"/> class.             
-        /// </summary>        
+        /// Initializes a new instance of the <see cref="ConstructionInfoBuilder"/> class.
+        /// </summary>
         /// <param name="typeConstructionInfoBuilderFactory">
         /// A function delegate used to provide a <see cref="ITypeConstructionInfoBuilder"/> instance.
         /// </param>
-        public ConstructionInfoBuilder(            
+        public ConstructionInfoBuilder(
             Func<ITypeConstructionInfoBuilder> typeConstructionInfoBuilderFactory)
         {
-            typeConstructionInfoBuilder = new Lazy<ITypeConstructionInfoBuilder>(typeConstructionInfoBuilderFactory);            
+            typeConstructionInfoBuilder = new Lazy<ITypeConstructionInfoBuilder>(typeConstructionInfoBuilderFactory);
         }
 
 #endif
@@ -6174,7 +6181,7 @@ namespace LightInject
         /// <returns>A <see cref="ConstructionInfo"/> instance that describes how to create a service instance.</returns>
         public ConstructionInfo Execute(Registration registration)
         {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
             return registration.FactoryExpression != null
                 ? CreateConstructionInfoFromLambdaExpression(registration.FactoryExpression)
                 : CreateConstructionInfoFromImplementingType(registration);
@@ -6192,38 +6199,38 @@ namespace LightInject
             return new ConstructionInfo { FactoryDelegate = factoryDelegate };
         }
 #endif
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
-        
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
+
         private ConstructionInfo CreateConstructionInfoFromLambdaExpression(LambdaExpression lambdaExpression)
         {
             return lambdaConstructionInfoBuilder.Value.Execute(lambdaExpression);
         }
 #endif
-        
+
         private ConstructionInfo CreateConstructionInfoFromImplementingType(Registration registration)
         {
             return typeConstructionInfoBuilder.Value.Execute(registration);
         }
     }
 
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
     /// <summary>
     /// Parses a <see cref="LambdaExpression"/> into a <see cref="ConstructionInfo"/> instance.
     /// </summary>
     internal class LambdaConstructionInfoBuilder : ILambdaConstructionInfoBuilder
-    {                
+    {
         /// <summary>
         /// Parses the <paramref name="lambdaExpression"/> and returns a <see cref="ConstructionInfo"/> instance.
         /// </summary>
         /// <param name="lambdaExpression">The <see cref="LambdaExpression"/> to parse.</param>
         /// <returns>A <see cref="ConstructionInfo"/> instance.</returns>
         public ConstructionInfo Execute(LambdaExpression lambdaExpression)
-        {            
+        {
             if (!CanParse(lambdaExpression))
             {
                 return CreateConstructionInfoBasedOnLambdaExpression(lambdaExpression);
             }
-            
+
             switch (lambdaExpression.Body.NodeType)
             {
                 case ExpressionType.New:
@@ -6237,7 +6244,7 @@ namespace LightInject
 
         private static bool CanParse(LambdaExpression lambdaExpression)
         {
-            return lambdaExpression.Body.AsEnumerable().All(e => e != null && e.NodeType != ExpressionType.Lambda) && lambdaExpression.Parameters.Count <= 1;            
+            return lambdaExpression.Body.AsEnumerable().All(e => e != null && e.NodeType != ExpressionType.Lambda) && lambdaExpression.Parameters.Count <= 1;
         }
 
         private static ConstructionInfo CreateConstructionInfoBasedOnLambdaExpression(LambdaExpression lambdaExpression)
@@ -6331,7 +6338,7 @@ namespace LightInject
         {
             return methodInfo.DeclaringType == typeof(IServiceFactory);
         }
-        
+
         private static void ApplyDependecyDetailsFromExpression(Expression expression, Dependency dependency)
         {
             dependency.FactoryExpression = expression;
@@ -6376,11 +6383,11 @@ namespace LightInject
             return argument.NodeType == ExpressionType.Constant;
         }
     }
-   
+
 #endif
     /// <summary>
     /// Contains information about a service request that originates from a rule based service registration.
-    /// </summary>    
+    /// </summary>
     internal class ServiceRequest
     {
         /// <summary>
@@ -6431,7 +6438,7 @@ namespace LightInject
         /// Gets or sets the <see cref="Type"/> that implements the <see cref="Registration.ServiceType"/>.
         /// </summary>
         public virtual Type ImplementingType { get; set; }
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
 
         /// <summary>
         /// Gets or sets the <see cref="LambdaExpression"/> used to create a service instance.
@@ -6453,7 +6460,7 @@ namespace LightInject
     internal class DecoratorRegistration : Registration
     {
         /// <summary>
-        /// Gets or sets a function delegate that determines if the decorator can decorate the service 
+        /// Gets or sets a function delegate that determines if the decorator can decorate the service
         /// represented by the supplied <see cref="ServiceRegistration"/>.
         /// </summary>
         public Func<ServiceRegistration, bool> CanDecorate { get; set; }
@@ -6475,14 +6482,14 @@ namespace LightInject
         {
             get
             {
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
                 return ImplementingType == null && FactoryExpression == null;
 #endif
 #if IOS
                 return ImplementingType == null && FactoryDelegate == null;
 #endif
             }
-        }       
+        }
     }
 
     /// <summary>
@@ -6506,13 +6513,13 @@ namespace LightInject
         public object Value { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="ServiceRegistration"/> can be overridden 
+        /// Gets or sets a value indicating whether this <see cref="ServiceRegistration"/> can be overridden
         /// by another registration.
         /// </summary>
         public bool IsReadOnly { get; set; }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
         /// A hash code for the current <see cref="T:System.Object"/>.
@@ -6542,7 +6549,7 @@ namespace LightInject
             return result;
         }
     }
-    
+
     /// <summary>
     /// Contains information about how to create a service instance.
     /// </summary>
@@ -6568,14 +6575,14 @@ namespace LightInject
         public ConstructorInfo Constructor { get; set; }
 
         /// <summary>
-        /// Gets a list of <see cref="PropertyDependency"/> instances that represent 
-        /// the property dependencies for the target service instance. 
+        /// Gets a list of <see cref="PropertyDependency"/> instances that represent
+        /// the property dependencies for the target service instance.
         /// </summary>
         public List<PropertyDependency> PropertyDependencies { get; private set; }
 
         /// <summary>
-        /// Gets a list of <see cref="ConstructorDependency"/> instances that represent 
-        /// the property dependencies for the target service instance. 
+        /// Gets a list of <see cref="ConstructorDependency"/> instances that represent
+        /// the property dependencies for the target service instance.
         /// </summary>
         public List<ConstructorDependency> ConstructorDependencies { get; private set; }
 
@@ -6602,9 +6609,9 @@ namespace LightInject
 
         /// <summary>
         /// Gets or sets the <see cref="FactoryExpression"/> that represent getting the value of the <see cref="Dependency"/>.
-        /// </summary>            
+        /// </summary>
         public Expression FactoryExpression { get; set; }
-       
+
         /// <summary>
         /// Gets the name of the dependency accessor.
         /// </summary>
@@ -6668,8 +6675,8 @@ namespace LightInject
         public ParameterInfo Parameter { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether that this parameter represents  
-        /// the decoration target passed into a decorator instance. 
+        /// Gets or sets a value indicating whether that this parameter represents
+        /// the decoration target passed into a decorator instance.
         /// </summary>
         public bool IsDecoratorTarget { get; set; }
 
@@ -6777,7 +6784,7 @@ namespace LightInject
     /// Ensures that only one service instance can exist within a given <see cref="Scope"/>.
     /// </summary>
     /// <remarks>
-    /// If the service instance implements <see cref="IDisposable"/>, 
+    /// If the service instance implements <see cref="IDisposable"/>,
     /// it will be disposed when the <see cref="Scope"/> ends.
     /// </remarks>
     internal class PerScopeLifetime : ILifetime
@@ -6852,7 +6859,7 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Starts a new <see cref="Scope"/>. 
+        /// Starts a new <see cref="Scope"/>.
         /// </summary>
         /// <returns>A new <see cref="Scope"/>.</returns>
         public Scope BeginScope()
@@ -6893,7 +6900,7 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Represents a scope. 
+    /// Represents a scope.
     /// </summary>
     internal class Scope : IDisposable
     {
@@ -7000,7 +7007,7 @@ namespace LightInject
             CompositionRootTypeAttribute[] compositionRootAttributes =
                 assembly.GetCustomAttributes(typeof(CompositionRootTypeAttribute))
                         .Cast<CompositionRootTypeAttribute>().ToArray();
-            
+
             if (compositionRootAttributes.Length > 0)
             {
                 return compositionRootAttributes.Select(a => a.CompositionRootType).ToArray();
@@ -7046,11 +7053,11 @@ namespace LightInject
     internal class ConcreteTypeExtractor : ITypeExtractor
     {
         private static readonly List<Type> InternalTypes = new List<Type>();
-       
+
         static ConcreteTypeExtractor()
-        {        
-#if NET || NET45 || NETFX_CORE || WINDOWS_PHONE
-            InternalTypes.Add(typeof(LambdaConstructionInfoBuilder));       
+        {
+#if NET || NET45 || DNX451 || DNXCORE50 || NETFX_CORE || WINDOWS_PHONE
+            InternalTypes.Add(typeof(LambdaConstructionInfoBuilder));
 #endif
             InternalTypes.Add(typeof(ConstructorDependency));
             InternalTypes.Add(typeof(PropertyDependency));
@@ -7065,13 +7072,13 @@ namespace LightInject
             InternalTypes.Add(typeof(Registration));
             InternalTypes.Add(typeof(ServiceContainer));
             InternalTypes.Add(typeof(ConstructionInfo));
-#if NET || NET45
-            InternalTypes.Add(typeof(AssemblyLoader));            
+#if NET || NET45 || DNX451
+            InternalTypes.Add(typeof(AssemblyLoader));
 #endif
             InternalTypes.Add(typeof(TypeConstructionInfoBuilder));
             InternalTypes.Add(typeof(ConstructionInfoProvider));
-            InternalTypes.Add(typeof(ConstructionInfoBuilder));            
-            InternalTypes.Add(typeof(MostResolvableConstructorSelector));            
+            InternalTypes.Add(typeof(ConstructionInfoBuilder));
+            InternalTypes.Add(typeof(MostResolvableConstructorSelector));
             InternalTypes.Add(typeof(PerContainerLifetime));
             InternalTypes.Add(typeof(PerContainerLifetime));
             InternalTypes.Add(typeof(PerRequestLifeTime));
@@ -7088,17 +7095,17 @@ namespace LightInject
             InternalTypes.Add(typeof(KeyValue<,>));
             InternalTypes.Add(typeof(ImmutableHashTree<,>));
             InternalTypes.Add(typeof(ImmutableHashTable<,>));
-            InternalTypes.Add(typeof(PerThreadScopeManagerProvider));            
+            InternalTypes.Add(typeof(PerThreadScopeManagerProvider));
             InternalTypes.Add(typeof(Emitter));
             InternalTypes.Add(typeof(Instruction));
             InternalTypes.Add(typeof(Instruction<>));
             InternalTypes.Add(typeof(GetInstanceDelegate));
             InternalTypes.Add(typeof(ContainerOptions));
-#if NET45            
+#if NET45 || DNX451
             InternalTypes.Add(typeof(PerLogicalCallContextScopeManagerProvider));
             InternalTypes.Add(typeof(LogicalThreadStorage<>));
-#endif            
-#if NETFX_CORE || WINDOWS_PHONE || IOS           
+#endif
+#if NETFX_CORE || WINDOWS_PHONE || IOS
             InternalTypes.Add(typeof(DynamicMethod));
             InternalTypes.Add(typeof(ILGenerator));
             InternalTypes.Add(typeof(LocalBuilder));
@@ -7108,7 +7115,7 @@ namespace LightInject
             InternalTypes.Add(typeof(ThreadLocal<>.Holder));
 #endif
 #if IOS
-            InternalTypes.Add(typeof(ExecutionContext));    
+            InternalTypes.Add(typeof(ExecutionContext));
 #endif
         }
 
@@ -7118,10 +7125,10 @@ namespace LightInject
         /// <param name="assembly">The <see cref="Assembly"/> for which to extract types.</param>
         /// <returns>A set of concrete types found in the given <paramref name="assembly"/>.</returns>
         public Type[] Execute(Assembly assembly)
-        {            
+        {
             return assembly.GetTypes().Where(t => t.IsClass()
                                                && !t.IsNestedPrivate()
-                                               && !t.IsAbstract() 
+                                               && !t.IsAbstract()
                                                && !Equals(t.GetAssembly(), typeof(string).GetAssembly())
                                                && !IsCompilerGenerated(t)).Except(InternalTypes).ToArray();
         }
@@ -7140,7 +7147,7 @@ namespace LightInject
         private readonly IServiceRegistry serviceRegistry;
 
         private readonly IList<Type> executedCompositionRoots = new List<Type>();
-        
+
         private readonly object syncRoot = new object();
 
         /// <summary>
@@ -7169,13 +7176,13 @@ namespace LightInject
                         compositionRoot.Compose(serviceRegistry);
                     }
                 }
-            }            
-        }       
+            }
+        }
     }
 
     /// <summary>
     /// An assembly scanner that registers services based on the types contained within an <see cref="Assembly"/>.
-    /// </summary>    
+    /// </summary>
     internal class AssemblyScanner : IAssemblyScanner
     {
         private readonly ITypeExtractor concreteTypeExtractor;
@@ -7186,11 +7193,11 @@ namespace LightInject
         /// <summary>
         /// Initializes a new instance of the <see cref="AssemblyScanner"/> class.
         /// </summary>
-        /// <param name="concreteTypeExtractor">The <see cref="ITypeExtractor"/> that is responsible for 
+        /// <param name="concreteTypeExtractor">The <see cref="ITypeExtractor"/> that is responsible for
         /// extracting concrete types from the assembly being scanned.</param>
-        /// <param name="compositionRootTypeExtractor">The <see cref="ITypeExtractor"/> that is responsible for 
+        /// <param name="compositionRootTypeExtractor">The <see cref="ITypeExtractor"/> that is responsible for
         /// extracting <see cref="ICompositionRoot"/> implementations from the assembly being scanned.</param>
-        /// <param name="compositionRootExecutor">The <see cref="ICompositionRootExecutor"/> that is 
+        /// <param name="compositionRootExecutor">The <see cref="ICompositionRootExecutor"/> that is
         /// responsible for creating and executing an <see cref="ICompositionRoot"/>.</param>
         public AssemblyScanner(ITypeExtractor concreteTypeExtractor, ITypeExtractor compositionRootTypeExtractor, ICompositionRootExecutor compositionRootExecutor)
         {
@@ -7202,12 +7209,12 @@ namespace LightInject
         /// <summary>
         /// Scans the target <paramref name="assembly"/> and registers services found within the assembly.
         /// </summary>
-        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>        
+        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>
         /// <param name="serviceRegistry">The target <see cref="IServiceRegistry"/> instance.</param>
         /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of the registered service.</param>
         /// <param name="shouldRegister">A function delegate that determines if a service implementation should be registered.</param>
         public void Scan(Assembly assembly, IServiceRegistry serviceRegistry, Func<ILifetime> lifetimeFactory, Func<Type, Type, bool> shouldRegister)
-        {            
+        {
             Type[] concreteTypes = GetConcreteTypes(assembly);
             foreach (Type type in concreteTypes)
             {
@@ -7218,7 +7225,7 @@ namespace LightInject
         /// <summary>
         /// Scans the target <paramref name="assembly"/> and executes composition roots found within the <see cref="Assembly"/>.
         /// </summary>
-        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>        
+        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>
         /// <param name="serviceRegistry">The target <see cref="IServiceRegistry"/> instance.</param>
         public void Scan(Assembly assembly, IServiceRegistry serviceRegistry)
         {
@@ -7227,7 +7234,7 @@ namespace LightInject
             {
                 currentAssembly = assembly;
                 ExecuteCompositionRoots(compositionRootTypes);
-            }            
+            }
         }
 
         private static string GetServiceName(Type serviceType, Type implementingType)
@@ -7269,7 +7276,7 @@ namespace LightInject
 
         private Type[] GetConcreteTypes(Assembly assembly)
         {
-            return concreteTypeExtractor.Execute(assembly);            
+            return concreteTypeExtractor.Execute(assembly);
         }
 
         private Type[] GetCompositionRootTypes(Assembly assembly)
@@ -7338,7 +7345,7 @@ namespace LightInject
             return propertyInfo.GetSetMethod() == null || propertyInfo.GetSetMethod().IsStatic || propertyInfo.GetSetMethod().IsPrivate || propertyInfo.GetIndexParameters().Length > 0;
         }
     }
-#if NET || NET45
+#if NET || NET45 || DNX451
 
     /// <summary>
     /// Loads all assemblies from the application base directory that matches the given search pattern.
@@ -7374,9 +7381,9 @@ namespace LightInject
         }
     }
 #endif
-  
+
     /// <summary>
-    /// Defines an immutable representation of a key and a value.  
+    /// Defines an immutable representation of a key and a value.
     /// </summary>
     /// <typeparam name="TKey">The type of the key.</typeparam>
     /// <typeparam name="TValue">The type of the value.</typeparam>
@@ -7465,12 +7472,12 @@ namespace LightInject
         /// An empty <see cref="ImmutableHashTree{TKey,TValue}"/>.
         /// </summary>
         public static readonly ImmutableHashTable<TKey, TValue> Empty = new ImmutableHashTable<TKey, TValue>();
-        
+
         /// <summary>
         /// Gets the number of items stored in the hash table.
         /// </summary>
         public readonly int Count;
-       
+
         /// <summary>
         /// Gets the hast table buckets.
         /// </summary>
@@ -7480,7 +7487,7 @@ namespace LightInject
         /// Gets the divisor used to calculate the bucket index from the hash code of the key.
         /// </summary>
         internal readonly int Divisor;
-       
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableHashTable{TKey,TValue}"/> class.
         /// </summary>
@@ -7564,7 +7571,7 @@ namespace LightInject
         public readonly TValue Value;
 
         /// <summary>
-        /// The list of <see cref="KeyValue{TKey,TValue}"/> instances where the 
+        /// The list of <see cref="KeyValue{TKey,TValue}"/> instances where the
         /// <see cref="KeyValue{TKey,TValue}.Key"/> has the same hash code as this <see cref="ImmutableHashTree{TKey,TValue}"/>.
         /// </summary>
         public readonly ImmutableList<KeyValue<TKey, TValue>> Duplicates;
@@ -7646,7 +7653,7 @@ namespace LightInject
                     left = RotateLeft(left);
                 }
 
-                // Rotate right                    
+                // Rotate right
                 Key = left.Key;
                 Value = left.Value;
                 Right = new ImmutableHashTree<TKey, TValue>(key, value, left.Right, right);
@@ -7775,7 +7782,7 @@ namespace LightInject
     }
 
     /// <summary>
-    /// An abstraction of the <see cref="ILGenerator"/> class that provides information 
+    /// An abstraction of the <see cref="ILGenerator"/> class that provides information
     /// about the <see cref="Type"/> currently on the stack.
     /// </summary>
     internal class Emitter : IEmitter
@@ -7797,7 +7804,7 @@ namespace LightInject
         /// <param name="parameterTypes">The list of parameter types used by the current dynamic method.</param>
         public Emitter(ILGenerator generator, Type[] parameterTypes)
         {
-            this.generator = generator;            
+            this.generator = generator;
             this.parameterTypes = parameterTypes;
         }
 
@@ -7820,7 +7827,7 @@ namespace LightInject
             get
             {
                 return instructions;
-            }            
+            }
         }
 
         /// <summary>
@@ -7832,7 +7839,7 @@ namespace LightInject
             if (code == OpCodes.Ldarg_0)
             {
                 stack.Push(parameterTypes[0]);
-            }            
+            }
             else if (code == OpCodes.Ldarg_1)
             {
                 stack.Push(parameterTypes[1]);
@@ -7879,7 +7886,7 @@ namespace LightInject
             }
             else if (code == OpCodes.Ldelem_Ref)
             {
-                stack.Pop();                
+                stack.Pop();
                 Type arrayType = stack.Pop();
                 stack.Push(arrayType.GetElementType());
             }
@@ -7928,7 +7935,7 @@ namespace LightInject
             else if (code == OpCodes.Ldc_I4_8)
             {
                 stack.Push(typeof(int));
-            }            
+            }
             else if (code == OpCodes.Sub)
             {
                 stack.Pop();
@@ -7962,7 +7969,7 @@ namespace LightInject
         {
             if (code == OpCodes.Ldc_I4)
             {
-                stack.Push(typeof(int));                
+                stack.Push(typeof(int));
             }
             else if (code == OpCodes.Ldarg)
             {
@@ -7981,9 +7988,9 @@ namespace LightInject
                 throw new NotSupportedException(code.ToString());
             }
 
-            instructions.Add(new Instruction<int>(code, arg, il => il.Emit(code, arg)));            
+            instructions.Add(new Instruction<int>(code, arg, il => il.Emit(code, arg)));
         }
-       
+
         /// <summary>
         /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
         /// </summary>
@@ -7993,14 +8000,14 @@ namespace LightInject
         {
             if (code == OpCodes.Ldc_I4_S)
             {
-                stack.Push(typeof(sbyte));    
+                stack.Push(typeof(sbyte));
             }
             else
             {
                 throw new NotSupportedException(code.ToString());
             }
 
-            instructions.Add(new Instruction<sbyte>(code, arg, il => il.Emit(code, arg)));            
+            instructions.Add(new Instruction<sbyte>(code, arg, il => il.Emit(code, arg)));
         }
 
         /// <summary>
@@ -8027,7 +8034,7 @@ namespace LightInject
                 throw new NotSupportedException(code.ToString());
             }
 
-            instructions.Add(new Instruction<byte>(code, arg, il => il.Emit(code, arg)));            
+            instructions.Add(new Instruction<byte>(code, arg, il => il.Emit(code, arg)));
         }
 
         /// <summary>
@@ -8040,35 +8047,35 @@ namespace LightInject
             if (code == OpCodes.Newarr)
             {
                 stack.Pop();
-                stack.Push(type.MakeArrayType());                
+                stack.Push(type.MakeArrayType());
             }
             else if (code == OpCodes.Stelem)
             {
                 stack.Pop();
                 stack.Pop();
-                stack.Pop();                
+                stack.Pop();
             }
             else if (code == OpCodes.Castclass)
             {
                 stack.Pop();
-                stack.Push(type);                
+                stack.Push(type);
             }
             else if (code == OpCodes.Box)
             {
                 stack.Pop();
-                stack.Push(typeof(object));                
+                stack.Push(typeof(object));
             }
             else if (code == OpCodes.Unbox_Any)
             {
                 stack.Pop();
-                stack.Push(type);                
+                stack.Push(type);
             }
             else
             {
                 throw new NotSupportedException(code.ToString());
             }
 
-            instructions.Add(new Instruction<Type>(code, type, il => il.Emit(code, type)));            
+            instructions.Add(new Instruction<Type>(code, type, il => il.Emit(code, type)));
         }
 
         /// <summary>
@@ -8093,7 +8100,7 @@ namespace LightInject
                 throw new NotSupportedException(code.ToString());
             }
 
-            instructions.Add(new Instruction<ConstructorInfo>(code, constructor, il => il.Emit(code, constructor)));            
+            instructions.Add(new Instruction<ConstructorInfo>(code, constructor, il => il.Emit(code, constructor)));
         }
 
         /// <summary>
@@ -8115,8 +8122,8 @@ namespace LightInject
             {
                 throw new NotSupportedException(code.ToString());
             }
-            
-            instructions.Add(new Instruction<LocalBuilder>(code, localBuilder, il => il.Emit(code, localBuilder)));                        
+
+            instructions.Add(new Instruction<LocalBuilder>(code, localBuilder, il => il.Emit(code, localBuilder)));
         }
 
         /// <summary>
@@ -8149,7 +8156,7 @@ namespace LightInject
                 throw new NotSupportedException(code.ToString());
             }
 
-            instructions.Add(new Instruction<MethodInfo>(code, methodInfo, il => il.Emit(code, methodInfo)));                                   
+            instructions.Add(new Instruction<MethodInfo>(code, methodInfo, il => il.Emit(code, methodInfo)));
         }
 
         /// <summary>
@@ -8164,14 +8171,14 @@ namespace LightInject
             return localBuilder;
         }
     }
-#if NET45
-    
+#if NET45 || DNX451
+
     /// <summary>
     /// Provides storage per logical thread of execution.
     /// </summary>
     /// <typeparam name="T">The type of the value contained in this <see cref="LogicalThreadStorage{T}"/>.</typeparam>
     internal class LogicalThreadStorage<T>
-    {      
+    {
         private readonly Func<T> valueFactory;
 
         private readonly string key;

--- a/LightInject/project.json
+++ b/LightInject/project.json
@@ -1,0 +1,30 @@
+{
+    "version": "3.0.0.10",
+    "dependencies": {},
+    "frameworks": {
+        "dnx451": {
+            "dependencies": {}
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Collections": "4.0.10-beta-*",
+                "System.Collections.Concurrent": "4.0.10-beta-*",
+                "System.IO": "4.0.10-beta-*",
+                "System.Linq": "4.0.0-beta-*",
+                "System.Linq.Expressions": "4.0.10-beta-*",
+                "System.Reflection": "4.0.10-beta-*",
+                "System.Reflection.Emit": "4.0.0-beta-*",
+                "System.Reflection.Emit.Lightweight": "4.0.0-beta-*",
+                "System.Reflection.Extensions": "4.0.0-beta-*",
+                "System.Reflection.TypeExtensions": "4.0.0-beta-*",
+                "System.Runtime": "4.0.20-*",
+                "System.Runtime.Extensions": "4.0.10-beta-*",
+                "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-*",
+                "System.Runtime.InteropServices": "4.0.20-beta-*",
+                "System.Text.Encoding": "4.0.10-beta-*",
+                "System.Text.RegularExpressions": "4.0.10-beta-*",
+                "System.Threading": "4.0.10-beta-*"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi there,

I was playing around with Visual Studio Code and DNX and was wondering how much effort it would take to get LightInject to compile for DNX451 (Full .NET) and DNXCORE50 (.NET Core).

DNX451 is basically NET45(1) - no changes required other than checking NET45 || DNX451. DNXCORE50 is a bit more complicated, due to the numerous libraries required and dependencies residing in different assemblies (e.g. DynamicMethod, Type.* methods).

The goal was to make LightInject compatible with DNX451 and DNXCORE50, without rewriting code.

The following is NOT available currently on DNXCORE50:

[MarshalByRefObj, Serializable not available](https://github.com/dotnet/corefx/issues/1272):
-> LogicalThreadStorage (PerLogicalCallContextScopeManagerProvider)

Assembly.CodeBase not available
-> AssemblyLoader(searchPattern)

Regards