### PR TITLE
Changed AssemblyLoader to use EscapedCodeBase

### DIFF
--- a/LightInject/LightInject.cs
+++ b/LightInject/LightInject.cs
@@ -7367,7 +7367,7 @@ namespace LightInject
         /// <returns>A list of assemblies based on the given <paramref name="searchPattern"/>.</returns>
         public IEnumerable<Assembly> Load(string searchPattern)
         {
-            string directory = Path.GetDirectoryName(new Uri(typeof(ServiceContainer).Assembly.CodeBase).LocalPath);
+            string directory = Path.GetDirectoryName(new Uri(typeof(ServiceContainer).Assembly.EscapedCodeBase).LocalPath);
             if (directory != null)
             {
                 string[] searchPatterns = searchPattern.Split('|');


### PR DESCRIPTION
Fixes a bug, if the CodeBase-Path contains "#" or similar characters that have meaning in URI-Strings.
