### PR TITLE
Simple solution to fix make generic method when proxy is an interface with a complex covariant type

### DIFF
--- a/LightInject.Interception.Tests/ProxyBuilderTests.cs
+++ b/LightInject.Interception.Tests/ProxyBuilderTests.cs
@@ -648,6 +648,16 @@ namespace LightInject.Interception.Tests
         }
 
         [TestMethod]
+        public void Execute_MethodWithCovariantTypeParameterAndGenericArgument_PassesValueToInterceptor()
+        {
+            var instance = CreateProxy<IMethodWithCovariantTypeParameterAndGenericArgument<Retval>>(new MethodWithCovariantTypeParameterAndGenericArgument(), "GetById");
+            var retval = instance.GetById(It.IsAny<object>());
+
+            Assert.IsNotNull(retval);
+            Assert.AreEqual(retval.Value, "value");
+        }
+
+        [TestMethod]
         public void Execute_MethodWithGenericValueType_ReturnsValueFromInterceptor()
         {
             var interceptorMock = new Mock<IInterceptor>();
@@ -812,6 +822,15 @@ namespace LightInject.Interception.Tests
             var proxyDefinition = new ProxyDefinition(typeof(T));
             var interceptor = CreateProceedingInterceptor();
             proxyDefinition.Implement(() => interceptor, m => m.Name == "Execute");
+            Type proxyType = CreateProxyBuilder().GetProxyType(proxyDefinition);
+            return (T)Activator.CreateInstance(proxyType, new Lazy<T>(() => target));
+        }
+
+        private T CreateProxy<T>(T target, string methodName)
+        {
+            var proxyDefinition = new ProxyDefinition(typeof(T));
+            var interceptor = CreateProceedingInterceptor();
+            proxyDefinition.Implement(() => interceptor, m => m.Name == methodName);
             Type proxyType = CreateProxyBuilder().GetProxyType(proxyDefinition);
             return (T)Activator.CreateInstance(proxyType, new Lazy<T>(() => target));
         }

--- a/LightInject.Interception.Tests/SampleInterfaces.cs
+++ b/LightInject.Interception.Tests/SampleInterfaces.cs
@@ -237,6 +237,24 @@
         T Execute();
     }
 
+    public interface IMethodWithCovariantTypeParameterAndGenericArgument<out TEntity>
+    {
+        TEntity GetById<TId>(TId id);
+    }
+
+    public class Retval
+    {
+        public string Value { get { return "value"; } }
+    }
+
+    public class MethodWithCovariantTypeParameterAndGenericArgument : IMethodWithCovariantTypeParameterAndGenericArgument<Retval>
+    {
+        public Retval GetById<TId>(TId arg)
+        {
+            return new Retval();
+        }
+    }
+
     public interface IMethodWithContravariantTypeParameter<in T>
     {
         void Execute(T value);

--- a/LightInject.Interception/LightInject.Interception.cs
+++ b/LightInject.Interception/LightInject.Interception.cs
@@ -465,9 +465,15 @@ namespace LightInject.Interception
 
         private TargetMethodInfo CreateTargetMethodInfo(Type[] types)
         {
-            var closedGenericMethod = openGenericMethod.MakeGenericMethod(types);
+            var openGenericMethodGenericMethodDefinitionReference = openGenericMethod;
+            if (!openGenericMethod.IsGenericMethodDefinition)
+                openGenericMethodGenericMethodDefinitionReference = openGenericMethod.GetGenericMethodDefinition();
+
+            var closedGenericMethod = openGenericMethodGenericMethodDefinitionReference.MakeGenericMethod(types);
+
             return new TargetMethodInfo(closedGenericMethod);
         }
+
     }
 
     /// <summary>


### PR DESCRIPTION
Hi,

I found some problems when try to access proxy methods created from complex generic interface with complex covariant type like code below...

```
    public interface IMethodWithCovariantTypeParameterAndGenericArgument<out TEntity>
    {
        TEntity GetById<TId>(TId id);
    }

```

... and found a simple solution. I'm not sure about that, if is the best solution, but, solve for me.

You have some open issue about this problem ?

Waiting for a feedback.

Thanks!

