### PR TITLE
Async LightInject: adding async CompositionRoots

### DIFF
--- a/src/LightInject.Tests/CompositionRootExecutorMock.cs
+++ b/src/LightInject.Tests/CompositionRootExecutorMock.cs
@@ -3,11 +3,18 @@ using LightMock;
 
 namespace LightInject.Tests
 {
+    using System.Threading.Tasks;
+
     internal class CompositionRootExecutorMock : MockContext<ICompositionRootExecutor>, ICompositionRootExecutor
     {
         public void Execute(Type compositionRootType)
         {
             ((IInvocationContext<ICompositionRootExecutor>) this).Invoke(c => c.Execute(compositionRootType));
+        }
+
+        public Task ExecuteAsync(Type compositionRootType)
+        {
+            return ((IInvocationContext<ICompositionRootExecutor>) this).Invoke(c => c.ExecuteAsync(compositionRootType));
         }
     }
 }

--- a/src/LightInject.Tests/CompositionRootExecutorMock.cs
+++ b/src/LightInject.Tests/CompositionRootExecutorMock.cs
@@ -14,7 +14,8 @@ namespace LightInject.Tests
 
         public Task ExecuteAsync(Type compositionRootType)
         {
-            return ((IInvocationContext<ICompositionRootExecutor>) this).Invoke(c => c.ExecuteAsync(compositionRootType));
+            ((IInvocationContext<ICompositionRootExecutor>) this).Invoke(c => c.ExecuteAsync(compositionRootType));
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/LightInject.Tests/CompositionRootExecutorTests.cs
+++ b/src/LightInject.Tests/CompositionRootExecutorTests.cs
@@ -1,5 +1,6 @@
 namespace LightInject.Tests
 {
+    using System.Threading.Tasks;
     using LightMock;
     using Xunit;
 
@@ -26,6 +27,45 @@ namespace LightInject.Tests
             executor.Execute(typeof(CompositionRootMock));
             executor.Execute(typeof(CompositionRootMock));
             compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);           
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CompositionRootType_IsCreatedAndExecuted()
+        {
+            CompositionRootMock compositionRootMock = new CompositionRootMock();
+            AsyncCompositionRootMock asyncCompositionRootMock = new AsyncCompositionRootMock();
+            var serviceContainerMock = new ContainerMock();
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock, (t) => asyncCompositionRootMock);
+            await executor.ExecuteAsync(typeof(AsyncCompositionRootMock));
+            asyncCompositionRootMock.Assert(c => c.ComposeAsync(The<IServiceContainer>.IsAnyValue), Invoked.Once);            
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CompositionRootType_IsCreatedAndExecutedOnlyOnce()
+        {
+            CompositionRootMock compositionRootMock = new CompositionRootMock();
+            AsyncCompositionRootMock asyncCompositionRootMock = new AsyncCompositionRootMock();
+            var serviceContainerMock = new ContainerMock();
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock, (t) => asyncCompositionRootMock);
+            await executor.ExecuteAsync(typeof(AsyncCompositionRootMock));
+            await executor.ExecuteAsync(typeof(AsyncCompositionRootMock));
+            asyncCompositionRootMock.Assert(c => c.ComposeAsync(The<IServiceContainer>.IsAnyValue), Invoked.Once);            
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_CompositionRootType_IsCreatedAndExecutedOnlyOnceWithParallel()
+        {
+            CompositionRootMock compositionRootMock = new CompositionRootMock();
+            AsyncCompositionRootMock asyncCompositionRootMock = new AsyncCompositionRootMock();
+            var serviceContainerMock = new ContainerMock();
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock, (t) => asyncCompositionRootMock);
+
+            var first = executor.ExecuteAsync(typeof(AsyncCompositionRootMock));
+            var second = executor.ExecuteAsync(typeof(AsyncCompositionRootMock));
+
+            await Task.WhenAll(first, second);
+
+            asyncCompositionRootMock.Assert(c => c.ComposeAsync(The<IServiceContainer>.IsAnyValue), Invoked.Once);            
         }
     }
 }

--- a/src/LightInject.Tests/CompositionRootExecutorTests.cs
+++ b/src/LightInject.Tests/CompositionRootExecutorTests.cs
@@ -1,16 +1,17 @@
 namespace LightInject.Tests
-{    
+{
     using LightMock;
-    using Xunit;    
-    
+    using Xunit;
+
     public class CompositionRootExecutorTests
     {
         [Fact]
         public void Execute_CompositionRootType_IsCreatedAndExecuted()
         {            
             CompositionRootMock compositionRootMock = new CompositionRootMock();
+            AsyncCompositionRootMock asyncCompositionRootMock = new AsyncCompositionRootMock();
             var serviceContainerMock = new ContainerMock();
-            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock);
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock, (t) => asyncCompositionRootMock);
             executor.Execute(typeof(CompositionRootMock));
             compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);            
         }
@@ -19,8 +20,9 @@ namespace LightInject.Tests
         public void Execute_CompositionRootType_IsCreatedAndExecutedOnlyOnce()
         {            
             CompositionRootMock compositionRootMock = new CompositionRootMock();
+            AsyncCompositionRootMock asyncCompositionRootMock = new AsyncCompositionRootMock();
             var serviceContainerMock = new ContainerMock();
-            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock);
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock, (t) => asyncCompositionRootMock);
             executor.Execute(typeof(CompositionRootMock));
             executor.Execute(typeof(CompositionRootMock));
             compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);           

--- a/src/LightInject.Tests/CompositionRootMock.cs
+++ b/src/LightInject.Tests/CompositionRootMock.cs
@@ -1,13 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using LightMock;
 
 namespace LightInject.Tests
 {
-   
+
 
     internal class CompositionRootMock : MockContext<ICompositionRoot>, ICompositionRoot
     {
@@ -22,6 +18,14 @@ namespace LightInject.Tests
         public void Compose(IServiceRegistry serviceRegistry)
         {
             ((IInvocationContext<ICompositionRoot>)this).Invoke(c => c.Compose(serviceRegistry));
+        }
+    }
+
+    internal class AsyncCompositionRootMock : MockContext<IAsyncCompositionRoot>, IAsyncCompositionRoot
+    {
+        public Task ComposeAsync(IServiceRegistry serviceRegistry)
+        {
+            return ((IInvocationContext<IAsyncCompositionRoot>)this).Invoke(c => c.ComposeAsync(serviceRegistry));
         }
     }
 }

--- a/src/LightInject.Tests/CompositionRootMock.cs
+++ b/src/LightInject.Tests/CompositionRootMock.cs
@@ -25,7 +25,8 @@ namespace LightInject.Tests
     {
         public Task ComposeAsync(IServiceRegistry serviceRegistry)
         {
-            return ((IInvocationContext<IAsyncCompositionRoot>)this).Invoke(c => c.ComposeAsync(serviceRegistry));
+            ((IInvocationContext<IAsyncCompositionRoot>)this).Invoke(c => c.ComposeAsync(serviceRegistry));
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -2,8 +2,8 @@ namespace LightInject.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq.Expressions;
     using System.Reflection;
+    using System.Threading.Tasks;
     using LightMock;
 
     internal class ContainerMock : MockContext<IServiceContainer>, IServiceContainer
@@ -188,6 +188,11 @@ namespace LightInject.Tests
         }
 
         public void RegisterFrom<TCompositionRoot>() where TCompositionRoot : ICompositionRoot, new()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RegisterFromAsync<TAsyncCompositionRoot>() where TAsyncCompositionRoot : IAsyncCompositionRoot, new()
         {
             throw new NotImplementedException();
         }

--- a/src/LightInject.Tests/LazyCompositionRootTests.cs
+++ b/src/LightInject.Tests/LazyCompositionRootTests.cs
@@ -21,13 +21,14 @@ namespace LightInject.Tests
         {
             var container = new ServiceContainer();
             var compositionRootMock = new CompositionRootMock();
+            var asyncCompositionRootMock = new AsyncCompositionRootMock();
             compositionRootMock.Arrange(c => c.Compose(container)).Callback<IServiceContainer>(c => c.Register<IFoo, Foo>());
 
             var compositionRootTypeExtractorMock = new TypeExtractorMock();
             compositionRootTypeExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(new[] {typeof(CompositionRootMock)});
 
             var assemblyScanner = new AssemblyScanner(new ConcreteTypeExtractor(), compositionRootTypeExtractorMock,
-                new CompositionRootExecutor(container, t => compositionRootMock));
+                new CompositionRootExecutor(container, t => compositionRootMock, t => asyncCompositionRootMock));
 
             container.AssemblyScanner = assemblyScanner;
 

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -5,21 +5,17 @@ namespace LightInject.Tests
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;    
-    using System.Security;
-    
+    using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
-
     using LightInject;
     using LightInject.SampleLibrary;
     using Xunit;
-    using Xunit.Sdk;
-    using Foo = LightInject.SampleLibrary.Foo;
-    using IFoo = LightInject.SampleLibrary.IFoo;
-    using IBar = LightInject.SampleLibrary.IBar;
     using Bar = LightInject.SampleLibrary.Bar;
-    
+    using Foo = LightInject.SampleLibrary.Foo;
+    using IBar = LightInject.SampleLibrary.IBar;
+    using IFoo = LightInject.SampleLibrary.IFoo;
+
     public class ServiceContainerTests : TestBase
     {
         #region InputValidation
@@ -1600,7 +1596,20 @@ namespace LightInject.Tests
 
             compositionRootExecutorMock.Assert(c => c.Execute(typeof(CompositionRootMock)), Invoked.Once);
         }
-#endif        
+#endif
+
+        [Fact]
+        public async Task RegisterFromAsync_CompositionRoot_CallsCompositionRootExecutor()
+        {
+            var container = (ServiceContainer)CreateContainer();
+            var compositionRootExecutorMock = new CompositionRootExecutorMock();
+            container.CompositionRootExecutor = compositionRootExecutorMock;
+
+            await container.RegisterFromAsync<AsyncCompositionRootMock>();
+
+            compositionRootExecutorMock.Assert(c => c.ExecuteAsync(typeof(AsyncCompositionRootMock)), Invoked.Once);
+        }
+
         [Fact]
         public void GetInstance_SingletonInstance_EmitterIsProperlyPoppedOnConstructorException()
         {

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -57,6 +57,7 @@ namespace LightInject
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// A delegate that represent the dynamic method compiled to resolved service instances.
@@ -395,6 +396,14 @@ namespace LightInject
         /// <typeparam name="TCompositionRoot">The type of <see cref="ICompositionRoot"/> to register from.</typeparam>
         void RegisterFrom<TCompositionRoot>()
             where TCompositionRoot : ICompositionRoot, new();
+
+        /// <summary>
+        /// Asynchronously registers services from the given <typeparamref name="TAsyncCompositionRoot"/> type.
+        /// </summary>
+        /// <typeparam name="TAsyncCompositionRoot">The type of <see cref="IAsyncCompositionRoot"/> to register from.</typeparam>
+        /// <returns>A Task indicating registration has completed.</returns>
+        Task RegisterFromAsync<TAsyncCompositionRoot>()
+            where TAsyncCompositionRoot : IAsyncCompositionRoot, new();
 
         /// <summary>
         /// Registers a factory delegate to be used when resolving a constructor dependency for
@@ -778,6 +787,19 @@ namespace LightInject
     }
 
     /// <summary>
+    /// Represents a class that acts as an asynchronous composition root for an <see cref="IServiceRegistry"/> instance.
+    /// </summary>
+    public interface IAsyncCompositionRoot
+    {
+        /// <summary>
+        /// Composes services by adding services to the <paramref name="serviceRegistry"/>.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry"/>.</param>
+        /// /// <returns>A Task indicating composition has completed.</returns>
+        Task ComposeAsync(IServiceRegistry serviceRegistry);
+    }
+
+    /// <summary>
     /// Represents a class that extracts a set of types from an <see cref="Assembly"/>.
     /// </summary>
     public interface ITypeExtractor
@@ -954,6 +976,13 @@ namespace LightInject
         /// </summary>
         /// <param name="compositionRootType">The concrete <see cref="ICompositionRoot"/> type to be instantiated and executed.</param>
         void Execute(Type compositionRootType);
+
+        /// <summary>
+        /// Creates an instance of the <paramref name="asyncCompositionRootType"/> and executes the <see cref="IAsyncCompositionRoot.ComposeAsync"/> method.
+        /// </summary>
+        /// <param name="asyncCompositionRootType">The concrete <see cref="IAsyncCompositionRoot"/> type to be instantiated and executed.</param>
+        /// <returns>A task indicating the IAsyncCompositionRoot execution has completed.</returns>
+        Task ExecuteAsync(Type asyncCompositionRootType);
     }
 
     /// <summary>
@@ -1641,7 +1670,7 @@ namespace LightInject
             options = ContainerOptions.Default;
             var concreteTypeExtractor = new CachedTypeExtractor(new ConcreteTypeExtractor());
             CompositionRootTypeExtractor = new CachedTypeExtractor(new CompositionRootTypeExtractor(new CompositionRootAttributeExtractor()));
-            CompositionRootExecutor = new CompositionRootExecutor(this, type => (ICompositionRoot)Activator.CreateInstance(type));
+            CompositionRootExecutor = new CompositionRootExecutor(this, type => (ICompositionRoot)Activator.CreateInstance(type), type => (IAsyncCompositionRoot)Activator.CreateInstance(type));
             AssemblyScanner = new AssemblyScanner(concreteTypeExtractor, CompositionRootTypeExtractor, CompositionRootExecutor);
             PropertyDependencySelector = new PropertyDependencySelector(new PropertySelector());
             ConstructorDependencySelector = new ConstructorDependencySelector();
@@ -1918,6 +1947,17 @@ namespace LightInject
             where TCompositionRoot : ICompositionRoot, new()
         {
             CompositionRootExecutor.Execute(typeof(TCompositionRoot));
+        }
+
+        /// <summary>
+        /// Asynchronously registers services from the given <typeparamref name="TAsyncCompositionRoot"/> type.
+        /// </summary>
+        /// <typeparam name="TAsyncCompositionRoot">The type of <see cref="IAsyncCompositionRoot"/> to register from.</typeparam>
+        /// <returns>A Task indicating the composition has completed.</returns>
+        public Task RegisterFromAsync<TAsyncCompositionRoot>()
+            where TAsyncCompositionRoot : IAsyncCompositionRoot, new()
+        {
+            return CompositionRootExecutor.ExecuteAsync(typeof(TAsyncCompositionRoot));
         }
 
         /// <summary>
@@ -5984,6 +6024,7 @@ namespace LightInject
     {
         private readonly IServiceRegistry serviceRegistry;
         private readonly Func<Type, ICompositionRoot> activator;
+        private readonly Func<Type, IAsyncCompositionRoot> asyncActivator;
 
         private readonly IList<Type> executedCompositionRoots = new List<Type>();
 
@@ -5994,10 +6035,12 @@ namespace LightInject
         /// </summary>
         /// <param name="serviceRegistry">The <see cref="IServiceRegistry"/> to be configured by the <see cref="ICompositionRoot"/>.</param>
         /// <param name="activator">The function delegate that is responsible for creating an instance of the <see cref="ICompositionRoot"/>.</param>
-        public CompositionRootExecutor(IServiceRegistry serviceRegistry, Func<Type, ICompositionRoot> activator)
+        /// <param name="asyncActivator">The function delegate that is responsible for creating an instance of the <see cref="IAsyncCompositionRoot"/>.</param>
+        public CompositionRootExecutor(IServiceRegistry serviceRegistry, Func<Type, ICompositionRoot> activator, Func<Type, IAsyncCompositionRoot> asyncActivator)
         {
             this.serviceRegistry = serviceRegistry;
             this.activator = activator;
+            this.asyncActivator = asyncActivator;
         }
 
         /// <summary>
@@ -6016,6 +6059,34 @@ namespace LightInject
                         var compositionRoot = activator(compositionRootType);
                         compositionRoot.Compose(serviceRegistry);
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates an instance of the <paramref name="asyncCompositionRootType"/> and executes the <see cref="IAsyncCompositionRoot.ComposeAsync"/> method.
+        /// </summary>
+        /// <param name="asyncCompositionRootType">The concrete <see cref="ICompositionRoot"/> type to be instantiated and executed.</param>
+        /// <returns>A task indicating composition has completed.</returns>
+        public async Task ExecuteAsync(Type asyncCompositionRootType)
+        {
+            if (!executedCompositionRoots.Contains(asyncCompositionRootType))
+            {
+                var wasAdded = false;
+
+                lock (syncRoot)
+                {
+                    if (!executedCompositionRoots.Contains(asyncCompositionRootType))
+                    {
+                        wasAdded = true;
+                        executedCompositionRoots.Add(asyncCompositionRootType);
+                    }
+                }
+
+                if (wasAdded)
+                {
+                    var asyncCompositionRoot = asyncActivator(asyncCompositionRootType);
+                    await asyncCompositionRoot.ComposeAsync(serviceRegistry);
                 }
             }
         }


### PR DESCRIPTION
This is going to be the first of a series of Pull Requests to enable asynchronous initialization of the LightInject `ServiceContainer`.

This first one is a small step: it adds `RegisterFromAsync<TAsyncCompositionRoot>()` as a counterpart to the current `RegisterFrom<TCompositionRoot>()`. `TAsyncCompositionRoot` is a type that must derive from the new `IAsyncCompositionRoot`.