### PR TITLE
Allow overriding of lifetime

### DIFF
--- a/src/LightInject.Tests/ServiceRegistrationTests.cs
+++ b/src/LightInject.Tests/ServiceRegistrationTests.cs
@@ -78,5 +78,25 @@ namespace LightInject.Tests
 
             Assert.IsAssignableFrom(typeof(AnotherFoo), instance);
         }
+
+        [Fact]
+        public void GetInstance_OverrideServiceLifetime_CreateInstanceWithOverriddenLifetime()
+        {
+            var container = new ServiceContainer();
+            container.Register<IFoo, Foo>();
+
+            container.Override(
+                sr => sr.ServiceType == typeof(IFoo),
+                (factory, registration) =>
+                {
+                    registration.Lifetime = new PerContainerLifetime();
+                    return registration;
+                });
+
+            var instance1 = container.GetInstance<IFoo>();
+            var instance2 = container.GetInstance<IFoo>();
+
+            Assert.Same(instance1, instance2);
+        }
     }
 }


### PR DESCRIPTION
We have an issue where we're scanning the assemblies but certain types that implement an interface have to be registered as PerContainerLifetime. We got around it by scanning the assemblies twice using the overloads with a predicate, however, looked like a simple change could be made to allow the Override method to be used.

Hope it's ok - let me know if you want me to make any changes.