### PR TITLE
Add option EnablePropertyInjection

### DIFF
--- a/src/LightInject.Tests/PropertyInjectionTests.cs
+++ b/src/LightInject.Tests/PropertyInjectionTests.cs
@@ -325,5 +325,19 @@ namespace LightInject.Tests
             var description = propertyDependency.ToString();
             Assert.StartsWith("[Target Type", description);
         }
+
+        [Fact]
+        public void Setting_EnablePropertyInjection_false_disables_property_injection()
+        {
+            var container = new ServiceContainer(new ContainerOptions {
+                EnablePropertyInjection = false
+            });
+            container.Register<object, Foo>();
+            container.Register<FooWithObjectProperty>();
+
+            var instance = container.GetInstance<FooWithObjectProperty>();
+
+            Assert.Null(instance.Property);
+        }
     }
 }

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1752,6 +1752,7 @@ namespace LightInject
         public ContainerOptions()
         {
             EnableVariance = true;
+            EnablePropertyInjection = true;
             LogFactory = t => message => { };
         }
 
@@ -1772,7 +1773,15 @@ namespace LightInject
         /// Gets or sets the log factory that crates the delegate used for logging.
         /// </summary>
         public Func<Type, Action<LogEntry>> LogFactory { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets a value indicating whether property injection is enabled.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public bool EnablePropertyInjection { get; set; }
+
         private static ContainerOptions CreateDefaultContainerOptions()
         {
             return new ContainerOptions();
@@ -1863,7 +1872,9 @@ namespace LightInject
             CompositionRootTypeExtractor = new CachedTypeExtractor(new CompositionRootTypeExtractor(new CompositionRootAttributeExtractor()));
             CompositionRootExecutor = new CompositionRootExecutor(this, type => (ICompositionRoot)Activator.CreateInstance(type));
             AssemblyScanner = new AssemblyScanner(concreteTypeExtractor, CompositionRootTypeExtractor, CompositionRootExecutor);
-            PropertyDependencySelector = new PropertyDependencySelector(new PropertySelector());
+            PropertyDependencySelector = options.EnablePropertyInjection 
+                ? (IPropertyDependencySelector) new PropertyDependencySelector(new PropertySelector())
+                : new PropertyDependencyDisabler();
             ConstructorDependencySelector = new ConstructorDependencySelector();
             ConstructorSelector = new MostResolvableConstructorSelector(CanGetInstance);
             constructionInfoProvider = new Lazy<IConstructionInfoProvider>(CreateConstructionInfoProvider);
@@ -3966,6 +3977,14 @@ namespace LightInject
                 var snapshot = new T[Items.Length + 1];
                 Array.Copy(Items, snapshot, Items.Length);
                 return snapshot;
+            }
+        }
+
+        private class PropertyDependencyDisabler : IPropertyDependencySelector
+        {
+            public IEnumerable<PropertyDependency> Execute(Type type)
+            {
+                return new PropertyDependency[0];
             }
         }
 


### PR DESCRIPTION
Makes it possible to set `EnablePropertyInjection` to `false` in `ContainerOptions`, which will use a no-op `PropertyInjectionDisabler` as `PropertyDependencySelector`.