### PR TITLE
RegisterFallback uses DefaultLifetime if set

### DIFF
--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1756,7 +1756,22 @@ namespace LightInject.Tests
             Assert.Same(bar1, bar2);
         }
 
-        
+        [Fact]
+        public void RegisterFallback_uses_DefaultLifetime_if_set()
+        {
+            var container = CreateContainer();
+            container.RegisterFallback((type, name) => type == typeof(IFoo), request => new Foo());
+            container.SetDefaultLifetime<PerContainerLifetime>();
+            container.RegisterFallback((type, name) => type == typeof(IBar), request => new Bar());
+
+            var foo1 = container.GetInstance<IFoo>();
+            var foo2 = container.GetInstance<IFoo>();
+            var bar1 = container.GetInstance<IBar>();
+            var bar2 = container.GetInstance<IBar>();
+
+            Assert.NotSame(foo1, foo2);
+            Assert.Same(bar1, bar2);
+        }
 
         [Fact]
         public void Can_chain_register_calls_and_get_same_instance_back()

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2062,8 +2062,7 @@ namespace LightInject
         /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
         public IServiceRegistry RegisterFallback(Func<Type, string, bool> predicate, Func<ServiceRequest, object> factory)
         {
-            factoryRules.Add(new FactoryRule { CanCreateInstance = predicate, Factory = factory });
-            return this;
+            return RegisterFallback(predicate, factory, DefaultLifetime);
         }
 
         /// <summary>


### PR DESCRIPTION
I expected that RegisterFallback would use DefaultLifetime if set, like all other Register-methods, but this didn't seem to be the case, so I made a test and fixed it.
