### PR TITLE
Don't scan generics with too many arguments

### DIFF
--- a/src/LightInject.Tests/Issue330.cs
+++ b/src/LightInject.Tests/Issue330.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests
+{
+    public class Issue330 : TestBase
+    {
+        [Fact]
+        public void Scan_assembly_ignores_open_generic_with_two_parameters_implementing_open_generic_with_one_parameter()
+        {
+            var container = CreateContainer();
+
+            container.RegisterAssembly(Assembly.GetExecutingAssembly(), (s, t) => t.FullName.Contains(nameof(Issue330)));
+
+            container.GetAllInstances<IFoo>();
+            container.TryGetInstance<IFoo<string>>();
+            container.TryGetInstance<ICollection<string>>();
+            container.TryGetInstance<IList<string>>();
+        }
+
+        [Fact]
+        public void Resolving_invalid_generic_registration_gives_detailed_error_message()
+        {
+            var container = CreateContainer();
+
+            container.Register(typeof(IFoo<>), typeof(Foo<,>));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => container.TryGetInstance<IFoo<string>>());
+            Assert.StartsWith("Generic parameter mismatch", exception.Message);
+        }
+
+        public interface IFoo<T> {}
+
+        public class Foo<T1, T2> : IFoo<T1> {}
+    }
+}

--- a/src/LightInject.Tests/Issue330.cs
+++ b/src/LightInject.Tests/Issue330.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
-using LightInject.SampleLibrary;
 using Xunit;
 
 namespace LightInject.Tests
@@ -15,10 +13,7 @@ namespace LightInject.Tests
 
             container.RegisterAssembly(Assembly.GetExecutingAssembly(), (s, t) => t.FullName.Contains(nameof(Issue330)));
 
-            container.GetAllInstances<IFoo>();
-            container.TryGetInstance<IFoo<string>>();
-            container.TryGetInstance<ICollection<string>>();
-            container.TryGetInstance<IList<string>>();
+            Assert.Null(container.TryGetInstance<IFoo<string>>());
         }
 
         [Fact]

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -89,10 +89,11 @@
     <Compile Include="Issue245.cs" />
     <Compile Include="Issue257.cs" />
     <Compile Include="Issue257Verification.cs" />
+    <Compile Include="Issue330.cs" />
     <Compile Include="LazyCompositionRootTests.cs" />
     <Compile Include="LoggingTests.cs" />
     <Compile Include="MethodBuilderMethodSkeleton.cs" />
-    <Compile Include="PerLogicalCallContextTests.cs" />    
+    <Compile Include="PerLogicalCallContextTests.cs" />
     <Compile Include="OpenGenericTests.cs" />
     <Compile Include="PropertyInjectionVerificationTests.cs" />
     <Compile Include="PropertySelectorTests.cs" />


### PR DESCRIPTION
Fixes an issue with partially closed generics and `GetAllInstances`, see #330.