### PR TITLE
Use Assembly.EscapedCodeBase to prevent errors for paths with characters like '#' 

### DIFF
--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -6590,7 +6590,7 @@ namespace LightInject
         /// <returns>A list of assemblies based on the given <paramref name="searchPattern"/>.</returns>
         public IEnumerable<Assembly> Load(string searchPattern)
         {
-            string directory = Path.GetDirectoryName(new Uri(typeof(ServiceContainer).Assembly.CodeBase).LocalPath);
+            string directory = Path.GetDirectoryName(new Uri(typeof(ServiceContainer).Assembly.EscapedCodeBase).LocalPath);
             if (directory != null)
             {
                 string[] searchPatterns = searchPattern.Split('|');


### PR DESCRIPTION
Hey.

I created a pull request about a year ago for this.

Just wanted to update and ask again if we could get this into LightInject.

Thanks,
Ruben