### PR TITLE
Option to disable assembly scanning when type missing from registry

### DIFF
--- a/src/LightInject.Tests/AssemblyScannerTests.cs
+++ b/src/LightInject.Tests/AssemblyScannerTests.cs
@@ -298,6 +298,32 @@ namespace LightInject.Tests
         }
 
         [Fact]
+        public void Register_Assembly_CallsAssemblyScannerWhenAssemblyScanningEnabled()
+        {
+            var scannerMock = new AssemblyScannerMock();
+            var compositionRootExtractorMock = new TypeExtractorMock();
+            compositionRootExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(Type.EmptyTypes);
+
+            var serviceContainer = new ServiceContainer(new ContainerOptions { ScanAssembliesWhenRegistrationNotFound = true });
+            serviceContainer.CompositionRootTypeExtractor = compositionRootExtractorMock;
+            serviceContainer.AssemblyScanner = scannerMock;
+            scannerMock.Assert(a => a.Scan(typeof(IFoo).Assembly, The<IServiceRegistry>.IsAnyValue, The<Func<ILifetime>>.IsAnyValue, The<Func<Type, Type, bool>>.IsAnyValue), Invoked.Never);
+        }
+
+        [Fact]
+        public void Register_Assembly_DoesNotCallsAssemblyScannerWhenAssemblyScanningDisabled()
+        {
+            var scannerMock = new AssemblyScannerMock();
+            var compositionRootExtractorMock = new TypeExtractorMock();
+            compositionRootExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(Type.EmptyTypes);
+
+            var serviceContainer = new ServiceContainer(new ContainerOptions { ScanAssembliesWhenRegistrationNotFound = false });
+            serviceContainer.CompositionRootTypeExtractor = compositionRootExtractorMock;
+            serviceContainer.AssemblyScanner = scannerMock;
+            scannerMock.Assert(a => a.Scan(typeof(IFoo).Assembly, The<IServiceRegistry>.IsAnyValue, The<Func<ILifetime>>.IsAnyValue, The<Func<Type, Type, bool>>.IsAnyValue), Invoked.Never);
+        }
+
+        [Fact]
         public void Register_AssemblyWithFuncAndLifeCycle_CallsAssemblyScanner()
         {            
             var scannerMock = new AssemblyScannerMock();

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1759,6 +1759,7 @@ namespace LightInject
         {
             EnableVariance = true;
             EnablePropertyInjection = true;
+            ScanAssembliesWhenRegistrationNotFound = true;
             LogFactory = t => message => { };
         }
 
@@ -1787,6 +1788,14 @@ namespace LightInject
         /// The default value is true.
         /// </remarks>
         public bool EnablePropertyInjection { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to scan assemblies when a type is not registered.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true.
+        /// </remarks>
+        public bool ScanAssembliesWhenRegistrationNotFound { get; set; }
 
         private static ContainerOptions CreateDefaultContainerOptions()
         {
@@ -1877,7 +1886,7 @@ namespace LightInject
             var concreteTypeExtractor = new CachedTypeExtractor(new ConcreteTypeExtractor());
             CompositionRootTypeExtractor = new CachedTypeExtractor(new CompositionRootTypeExtractor(new CompositionRootAttributeExtractor()));
             CompositionRootExecutor = new CompositionRootExecutor(this, type => (ICompositionRoot)Activator.CreateInstance(type));
-            PropertyDependencySelector = options.EnablePropertyInjection 
+            PropertyDependencySelector = options.EnablePropertyInjection
                 ? (IPropertyDependencySelector)new PropertyDependencySelector(new PropertySelector())
                 : new PropertyDependencyDisabler();
             GenericArgumentMapper = new GenericArgumentMapper();
@@ -3035,15 +3044,15 @@ namespace LightInject
                 emitMethod = TryGetFallbackEmitMethod(serviceType, serviceName);
             }
 
-            if (emitMethod == null)
+            if (emitMethod == null && options.ScanAssembliesWhenRegistrationNotFound)
             {
                 AssemblyScanner.Scan(serviceType.GetTypeInfo().Assembly, this);
                 emitMethod = GetRegisteredEmitMethod(serviceType, serviceName);
-            }
 
-            if (emitMethod == null)
-            {
-                emitMethod = TryGetFallbackEmitMethod(serviceType, serviceName);
+                if (emitMethod == null)
+                {
+                    emitMethod = TryGetFallbackEmitMethod(serviceType, serviceName);
+                }
             }
 
             return CreateEmitMethodWrapper(emitMethod, serviceType, serviceName);


### PR DESCRIPTION
Follow up on discussion https://github.com/seesharper/LightInject/issues/103.

Proposed change: to have an option to disable the default behaviour that scans assemblies for `ICompositionRoot` implementation when a type is missing from the service registry.

Having the option `ScanAssembliesWhenRegistrationNotFound` set to true by default doesn't change the current behaviour.