### PR TITLE
Make the disposableObjects thread-safe collection.

### DIFF
--- a/src/LightInject.Tests/DisposableListIsNotThreadSafe.cs
+++ b/src/LightInject.Tests/DisposableListIsNotThreadSafe.cs
@@ -1,0 +1,27 @@
+﻿namespace LightInject.Tests
+{
+    using System.Linq;
+    using LightInject.SampleLibrary;
+    using Xunit;
+
+    public class DisposableListIsNotThreadSafe
+    {
+        [Fact]
+        public void Init_ScopesWithDisposableService_DontThrowError()
+        {
+            ServiceContainer container = new ServiceContainer();
+
+            container.ScopeManagerProvider = new PerLogicalCallContextScopeManagerProvider();
+            
+            // Register disposable Foo.
+            container.Register<IFoo>(factory => new DisposableFoo(), new PerRequestLifeTime());
+
+            using (var scope = container.BeginScope())
+            {
+                Enumerable.Range(0, 100)
+                          .AsParallel()
+                          .ForAll(num => scope.GetInstance<IFoo>());
+            }
+        }
+    }
+}

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -5590,6 +5590,7 @@ namespace LightInject
     /// </summary>
     public class Scope : IServiceFactory, IDisposable
     {
+        private static readonly object disposableObjectsLock = new object();
         private readonly HashSet<IDisposable> disposableObjects = new HashSet<IDisposable>(ReferenceEqualityComparer<IDisposable>.Default);
         private readonly IScopeManager scopeManager;
         private readonly IServiceFactory serviceFactory;
@@ -5629,7 +5630,10 @@ namespace LightInject
         /// <param name="disposable">The <see cref="IDisposable"/> object to register.</param>
         public void TrackInstance(IDisposable disposable)
         {
-            disposableObjects.Add(disposable);
+            lock (disposableObjectsLock)
+            {
+                disposableObjects.Add(disposable);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Make the disposableObjects thread-safe collection. This prevent exception when accessed by 2 threads.

This occur in asp.net core application on startup. 1 out of 5 times the application pool recycle there is error that the list is accessed by 2 threads ant the application fail to start. There is a lot of async methods in the application. Using a nuget with this change solved the issue for us.