### PR TITLE
Version 5.1.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ build_script:
     csx build.csx pack
 test: off
 artifacts:
-- path: /**/*.nupkg
+- path: /**/LightInject*.nupkg
   name: NuGet Packages
 deploy:
   provider: NuGet  

--- a/build/build.csx
+++ b/build/build.csx
@@ -64,8 +64,8 @@ private void Compile()
 
 private void Test()
 {
-    //DotNet.Test(BuildContext.BinaryTestProjectFolder);
-    //DotNet.Test(BuildContext.SourceTestProjectFolder);    
+    DotNet.Test(BuildContext.BinaryTestProjectFolder);
+    DotNet.Test(BuildContext.SourceTestProjectFolder);    
     AnalyzeTestCoverage();    
 }
 

--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceRoot}/LightInject.Tests/bin/Debug/netcoreapp1.1/LightInject.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}/LightInject.Tests",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}/LightInject.Tests/LightInject.Tests.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/LightInject.Tests/AssemblyScannerTests.cs
+++ b/src/LightInject.Tests/AssemblyScannerTests.cs
@@ -94,8 +94,8 @@ namespace LightInject.Tests
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(AssemblyScannerTests).GetTypeInfo().Assembly, (s,i) => s == typeof(IFoo));
 
-            Assert.True(container.AvailableServices.Any(sr => sr.ServiceType == typeof(IFoo)));
-            Assert.False(container.AvailableServices.Any(sr => sr.ServiceType == typeof(IBar)));
+            Assert.Contains(container.AvailableServices, sr => sr.ServiceType == typeof(IFoo));
+            Assert.DoesNotContain(container.AvailableServices, sr => sr.ServiceType == typeof(IBar));
         }
 
         [Fact]
@@ -107,8 +107,8 @@ namespace LightInject.Tests
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(AssemblyScannerTests).GetTypeInfo().Assembly);
 
-            Assert.True(container.AvailableServices.Any(sr => sr.ServiceType == typeof(IFoo)));
-            Assert.True(container.AvailableServices.Any(sr => sr.ServiceType == typeof(IBar)));
+            Assert.Contains(container.AvailableServices, sr => sr.ServiceType == typeof(IFoo));
+            Assert.Contains(container.AvailableServices, sr => sr.ServiceType == typeof(IBar));
         }
 
 
@@ -161,7 +161,7 @@ namespace LightInject.Tests
             compositionRootExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(new[] { typeof(CompositionRootMock) });
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(Foo).GetTypeInfo().Assembly);
-            Assert.False(container.AvailableServices.Any(si => si.ImplementingType != null && si.ImplementingType.GetTypeInfo().IsDefined(typeof(CompilerGeneratedAttribute), false)));
+            Assert.DoesNotContain(container.AvailableServices, si => si.ImplementingType != null && si.ImplementingType.GetTypeInfo().IsDefined(typeof(CompilerGeneratedAttribute), false));
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace LightInject.Tests
             compositionRootExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(new[] { typeof(CompositionRootMock) });
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(Foo).GetTypeInfo().Assembly);
-            Assert.False(container.AvailableServices.Any(si => si.ImplementingType == typeof(AbstractFoo)));
+            Assert.DoesNotContain(container.AvailableServices, si => si.ImplementingType == typeof(AbstractFoo));
         }
 
         [Fact]
@@ -183,7 +183,7 @@ namespace LightInject.Tests
             compositionRootExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(new[] { typeof(CompositionRootMock) });
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(string).GetTypeInfo().Assembly);
-            Assert.Equal(0, container.AvailableServices.Count());
+            Assert.Empty(container.AvailableServices);
         }
 
         [Fact]
@@ -194,7 +194,7 @@ namespace LightInject.Tests
             compositionRootExtractorMock.Arrange(c => c.Execute(The<Assembly>.IsAnyValue)).Returns(new[] { typeof(CompositionRootMock) });
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(Foo).GetTypeInfo().Assembly);
-            Assert.False(container.AvailableServices.Any(si => si.ImplementingType.Name == "NestedPrivateBar"));
+            Assert.DoesNotContain(container.AvailableServices, si => si.ImplementingType.Name == "NestedPrivateBar");
         }
 
 
@@ -207,7 +207,7 @@ namespace LightInject.Tests
             container.CompositionRootTypeExtractor = compositionRootExtractorMock;
             container.RegisterAssembly(typeof(ServiceContainer).GetTypeInfo().Assembly);
             var result = container.AvailableServices.Where(si => si.ImplementingType.Namespace == "LightInject");
-            Assert.False(container.AvailableServices.Any(si => si.ImplementingType != null && si.ImplementingType.Namespace == "LightInject"));
+            Assert.DoesNotContain(container.AvailableServices, si => si.ImplementingType != null && si.ImplementingType.Namespace == "LightInject");
         }
         
         //[Fact]
@@ -329,7 +329,7 @@ namespace LightInject.Tests
 
             var service = container.AvailableServices.FirstOrDefault(sr => sr.ServiceType == typeof(IFoo));
 
-            Assert.IsAssignableFrom(typeof(PerContainerLifetime), service.Lifetime);
+            Assert.IsAssignableFrom<PerContainerLifetime>(service.Lifetime);
         }
     }
 }

--- a/src/LightInject.Tests/AsyncTests.cs
+++ b/src/LightInject.Tests/AsyncTests.cs
@@ -39,7 +39,7 @@ namespace LightInject.Tests
             {
                 var instance = container.GetInstance<IAsyncFoo>();
                 var bar = instance.GetBar().Result;
-                Assert.IsAssignableFrom(typeof(IBar), bar);
+                Assert.IsAssignableFrom<IBar>(bar);
             }
         }
 

--- a/src/LightInject.Tests/ConstructorInjectionTests.cs
+++ b/src/LightInject.Tests/ConstructorInjectionTests.cs
@@ -45,7 +45,7 @@ namespace LightInject.Tests
             container.Register(typeof(IBar<>), typeof(Bar<>));
             container.Register(typeof(IFoo<>), typeof(FooWithOpenGenericDependency<>));
             var instance = (FooWithOpenGenericDependency<int>)container.GetInstance<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(Bar<int>), instance.Dependency);
+            Assert.IsAssignableFrom<Bar<int>>(instance.Dependency);
         }
 
         [Fact]

--- a/src/LightInject.Tests/ConstructorInjectionTests.cs
+++ b/src/LightInject.Tests/ConstructorInjectionTests.cs
@@ -16,7 +16,7 @@ namespace LightInject.Tests
             container.Register(typeof(IBar), typeof(Bar));
             container.Register(typeof(IFoo), typeof(FooWithDependency));
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.Register(typeof(IFoo<>), typeof(FooWithGenericDependency<>));
             var instance = (FooWithGenericDependency<IBar>)container.GetInstance<IFoo<IBar>>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Dependency);
+            Assert.IsAssignableFrom<Bar>(instance.Dependency);
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace LightInject.Tests
             container.Register(typeof(IBar), typeof(Bar));
             container.Register(typeof(IFoo), typeof(FooWithFuncDependency));
             var instance = (FooWithFuncDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.GetBar());
+            Assert.IsAssignableFrom<Bar>(instance.GetBar());
         }
 
         [Fact]
@@ -266,8 +266,8 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo), typeof(FooWithEnumerableIFooDependency));            
             var instance = (FooWithEnumerableIFooDependency)container.GetInstance<IFoo>();
 
-            Assert.True(instance.FooList.Any(f => f.GetType() == typeof(Foo)));
-            Assert.True(instance.FooList.Any(f => f.GetType() == typeof(AnotherFoo)));
+            Assert.Contains(instance.FooList, f => f.GetType() == typeof(Foo));
+            Assert.Contains(instance.FooList, f => f.GetType() == typeof(AnotherFoo));
             Assert.Equal(2, instance.FooList.Count());
         }
 
@@ -312,7 +312,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register<IFoo>(factory => CreateRecursive(factory), new PerContainerLifetime());
             var exception = Assert.Throws<InvalidOperationException>(() => container.GetInstance<IFoo>());
-            Assert.True(exception.ToString().Contains("Recursive dependency detected"));            
+            Assert.Contains("Recursive dependency detected", exception.ToString());            
         }
 
         private static FooWithRecursiveDependency CreateRecursive(IServiceFactory factory)
@@ -354,7 +354,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register<IFoo>(factory => new FooWithDependency(this.CreateBar()));
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -394,7 +394,7 @@ namespace LightInject.Tests
             container.Register<IBar, AnotherBar>("AnotherBar");
             container.Register<IFoo, FooWithDependency>();
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]

--- a/src/LightInject.Tests/DecoratorTests.cs
+++ b/src/LightInject.Tests/DecoratorTests.cs
@@ -18,7 +18,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -29,8 +29,8 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.Decorate(typeof(IFoo), typeof(FooDecoratorWithDependency));
             var instance = (FooDecoratorWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(IFoo), instance.Foo);
-            Assert.IsAssignableFrom(typeof(IBar), instance.Bar);
+            Assert.IsAssignableFrom<IFoo>(instance.Foo);
+            Assert.IsAssignableFrom<IBar>(instance.Bar);
         }
 
         [Fact]
@@ -41,8 +41,8 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.Decorate(typeof(IFoo), typeof(FooDecoratorWithDependencyFirst));
             var instance = (FooDecoratorWithDependencyFirst)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(IFoo), instance.Foo);
-            Assert.IsAssignableFrom(typeof(IBar), instance.Bar);
+            Assert.IsAssignableFrom<IFoo>(instance.Foo);
+            Assert.IsAssignableFrom<IBar>(instance.Bar);
         }
 
 
@@ -53,7 +53,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>(new PerContainerLifetime());
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace LightInject.Tests
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             container.Decorate(typeof(IFoo), typeof(AnotherFooDecorator));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(AnotherFooDecorator), instance);
+            Assert.IsAssignableFrom<AnotherFooDecorator>(instance);
         }
 
         [Fact]
@@ -76,8 +76,8 @@ namespace LightInject.Tests
             container.Decorate(typeof(IFoo), typeof(FooDecorator), service => service.ServiceName == "AnotherFoo");
             var instance = container.GetInstance<IFoo>();
             var decoratedInstance = container.GetInstance<IFoo>("AnotherFoo");
-            Assert.IsAssignableFrom(typeof(Foo), instance);
-            Assert.IsAssignableFrom(typeof(FooDecorator), decoratedInstance);
+            Assert.IsAssignableFrom<Foo>(instance);
+            Assert.IsAssignableFrom<FooDecorator>(decoratedInstance);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace LightInject.Tests
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             container.Decorate(typeof(IFoo), typeof(AnotherFooDecorator));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(AnotherFooDecorator), instance);
+            Assert.IsAssignableFrom<AnotherFooDecorator>(instance);
         }
 
         [Fact]
@@ -99,8 +99,8 @@ namespace LightInject.Tests
             container.Register<IFoo, AnotherFoo>("AnotherFoo");
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             var instances = container.GetAllInstances<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instances.First());
-            Assert.IsAssignableFrom(typeof(FooDecorator), instances.Last());
+            Assert.IsAssignableFrom<FooDecorator>(instances.First());
+            Assert.IsAssignableFrom<FooDecorator>(instances.Last());
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(Foo<>));
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));
             var instance = container.GetInstance<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instance);
+            Assert.IsAssignableFrom<FooDecorator<int>>(instance);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ namespace LightInject.Tests
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));
             container.Decorate(typeof(IFoo<int>), typeof(ClosedGenericFooDecorator));
             var instance = container.GetInstance<IFoo<int>>();           
-            Assert.IsAssignableFrom(typeof(ClosedGenericFooDecorator), instance);
+            Assert.IsAssignableFrom<ClosedGenericFooDecorator>(instance);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace LightInject.Tests
             container.Decorate(typeof(IFoo<int>), typeof(ClosedGenericFooDecorator));
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));            
             var instance = container.GetInstance<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instance);
+            Assert.IsAssignableFrom<FooDecorator<int>>(instance);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace LightInject.Tests
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));
             container.Decorate(typeof(IFoo<>), typeof(AnotherFooDecorator<>));
             var instance = container.GetInstance<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(AnotherFooDecorator<int>), instance);
+            Assert.IsAssignableFrom<AnotherFooDecorator<int>>(instance);
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<int>), typeof(Foo<int>));
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));
             var instance = container.GetInstance<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instance);
+            Assert.IsAssignableFrom<FooDecorator<int>>(instance);
         }
 
         [Fact]
@@ -164,8 +164,8 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(AnotherFoo<>), "AnotherFoo");
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));
             var instances = container.GetAllInstances<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instances.First());
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instances.Last());
+            Assert.IsAssignableFrom<FooDecorator<int>>(instances.First());
+            Assert.IsAssignableFrom<FooDecorator<int>>(instances.Last());
         }
 
         [Fact]
@@ -176,8 +176,8 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(AnotherFoo<>), "AnotherFoo");
             container.Decorate(typeof(IFoo<>), typeof(FooDecorator<>));
             var instances = container.GetAllInstances<IFoo<int>>();
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instances.First());
-            Assert.IsAssignableFrom(typeof(FooDecorator<int>), instances.Last());
+            Assert.IsAssignableFrom<FooDecorator<int>>(instances.First());
+            Assert.IsAssignableFrom<FooDecorator<int>>(instances.Last());
         }
 
         [Fact]
@@ -192,7 +192,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo<int>>();
 
-            Assert.IsAssignableFrom(typeof(AnotherFooDecorator<int>), instance);
+            Assert.IsAssignableFrom<AnotherFooDecorator<int>>(instance);
         }
 
         [Fact]
@@ -207,7 +207,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.Decorate<IFoo>((serviceFactory, target) => new FooDecorator(target));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -229,8 +229,8 @@ namespace LightInject.Tests
             container.Decorate<IFoo>((serviceFactory, target) 
                 => new FooDecoratorWithDependency(target, serviceFactory.GetInstance<IBar>()));
             var instance = (FooDecoratorWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(IFoo), instance.Foo);
-            Assert.IsAssignableFrom(typeof(IBar), instance.Bar);
+            Assert.IsAssignableFrom<IFoo>(instance.Foo);
+            Assert.IsAssignableFrom<IBar>(instance.Bar);
         }
 
         [Fact]
@@ -242,8 +242,8 @@ namespace LightInject.Tests
             container.Decorate<IFoo>((serviceFactory, target)
                 => new FooDecoratorWithDependencyFirst(serviceFactory.GetInstance<IBar>(), target));
             var instance = (FooDecoratorWithDependencyFirst)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(IFoo), instance.Foo);
-            Assert.IsAssignableFrom(typeof(IBar), instance.Bar);
+            Assert.IsAssignableFrom<IFoo>(instance.Foo);
+            Assert.IsAssignableFrom<IBar>(instance.Bar);
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.Decorate<IFoo>((serviceFactory, target) => GetFooDecorator(target));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -263,7 +263,7 @@ namespace LightInject.Tests
             container.RegisterFallback((serviceType, serviceName) => serviceType == typeof(IFoo), request => new Foo());
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.Decorate<IFoo>((factory, foo) => new LazyFooDecorator(new Lazy<IFoo>(factory.GetInstance<IFoo>)));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(LazyFooDecorator), instance);
+            Assert.IsAssignableFrom<LazyFooDecorator>(instance);
         }
 
         [Fact]
@@ -295,7 +295,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.Decorate(typeof(IFoo), typeof(LazyFooDecorator));
             var instance = (LazyFooDecorator)container.GetInstance<IFoo>();                     
-            Assert.IsAssignableFrom(typeof(Foo), instance.Foo.Value);
+            Assert.IsAssignableFrom<Foo>(instance.Foo.Value);
         }
 
         [Fact]
@@ -308,7 +308,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(AnotherLazyFooDecorator), instance);
+            Assert.IsAssignableFrom<AnotherLazyFooDecorator>(instance);
         }
 
 
@@ -323,7 +323,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(LazyFooDecorator), instance);
+            Assert.IsAssignableFrom<LazyFooDecorator>(instance);
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
 
@@ -416,7 +416,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace LightInject.Tests
             container.Register<IFoo>(factory => CreateFoo());
             container.Decorate(typeof(IFoo), typeof(FooDecorator));
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
         }
 
         [Fact]
@@ -467,7 +467,7 @@ namespace LightInject.Tests
             container.Decorate(typeof(IBar), typeof(BarDecorator));
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(BarDecorator), instance.Bar);
+            Assert.IsAssignableFrom<BarDecorator>(instance.Bar);
         }
 
         [Fact]
@@ -479,7 +479,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<int, IFoo>(42);
 
-            Assert.IsAssignableFrom(typeof(FooDecorator), instance);
+            Assert.IsAssignableFrom<FooDecorator>(instance);
 
         }
 

--- a/src/LightInject.Tests/EmitterTests.cs
+++ b/src/LightInject.Tests/EmitterTests.cs
@@ -3,9 +3,6 @@ namespace LightInject.Tests
     using System;
     using System.Reflection;
     using System.Reflection.Emit;
-#if NET452 || NET46
-    using System.Reflection.Emit;
-#endif
 
     using Xunit;
     

--- a/src/LightInject.Tests/EmitterTests.cs
+++ b/src/LightInject.Tests/EmitterTests.cs
@@ -10,7 +10,7 @@ namespace LightInject.Tests
     using Xunit;
     
 
-#if NETSTANDARD1_1 || NETSTANDARD1_3 || NETCOREAPP1_1
+#if NETSTANDARD1_1 || NETSTANDARD1_3 || NETCOREAPP2_0
     using LocalBuilder = LightInject.LocalBuilder;
     using ILGenerator = LightInject.ILGenerator;
 #endif
@@ -673,7 +673,7 @@ namespace LightInject.Tests
             return new DynamicMethod(string.Empty, typeof(object), new Type[]{typeof(object[])}).GetILGenerator();
         }
 #endif
-#if NETSTANDARD1_1 || NETSTANDARD1_3 || NETCOREAPP1_1
+#if NETSTANDARD1_1 || NETSTANDARD1_3 || NETCOREAPP2_0
         private ILGenerator CreateDummyGenerator(Type[] parameterTypes)
         {
             return new LightInject.DynamicMethod(typeof(object), parameterTypes).GetILGenerator();

--- a/src/LightInject.Tests/FunctionFactoryTests.cs
+++ b/src/LightInject.Tests/FunctionFactoryTests.cs
@@ -15,7 +15,7 @@ namespace LightInject.Tests
             container.Register<IFoo>(factory => new Foo());
             var fooFactory = container.GetInstance<Func<IFoo>>();
             var instance = fooFactory();
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace LightInject.Tests
             container.Register<IFoo>(factory => new Foo(), "SomeFoo");
             var fooFactory = container.GetInstance<Func<IFoo>>("SomeFoo");
             var instance = fooFactory();
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
        
         [Fact]
@@ -63,7 +63,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();            
             var instance = container.GetInstance<Func<int, IFoo>>();
-            Assert.IsAssignableFrom(typeof(Func<int, IFoo>), instance);
+            Assert.IsAssignableFrom<Func<int, IFoo>>(instance);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var instance = container.GetInstance<Func<int, int, IFoo>>();
-            Assert.IsAssignableFrom(typeof(Func<int, int, IFoo>), instance);
+            Assert.IsAssignableFrom<Func<int, int, IFoo>>(instance);
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var instance = container.GetInstance<Func<int, int, int, IFoo>>();
-            Assert.IsAssignableFrom(typeof(Func<int, int, int, IFoo>), instance);
+            Assert.IsAssignableFrom<Func<int, int, int, IFoo>>(instance);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var instance = container.GetInstance<Func<int, int, int, int, IFoo>>();
-            Assert.IsAssignableFrom(typeof(Func<int, int, int, int, IFoo>), instance);
+            Assert.IsAssignableFrom<Func<int, int, int, int, IFoo>>(instance);
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register<int, IFoo>((factory, i) => new FooWithValueTypeDependency(i), "SomeFoo");
             var instance = container.GetInstance<Func<int, IFoo>>("SomeFoo");
-            Assert.IsAssignableFrom(typeof(Func<int, IFoo>), instance);
+            Assert.IsAssignableFrom<Func<int, IFoo>>(instance);
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace LightInject.Tests
             container.Register<int, IFoo>((factory, i) => new AnotherFooWithValueTypeDependency(i), "AnotherFoo");
             var firstFactory = container.GetInstance<Func<int, IFoo>>("SomeFoo");
             var instance = firstFactory(42);
-            Assert.IsAssignableFrom(typeof(FooWithValueTypeDependency), instance);
+            Assert.IsAssignableFrom<FooWithValueTypeDependency>(instance);
         }
 
         [Fact]

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-      <PackageReference Include="xunit" Version="2.2.0" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+      <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
   </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
         <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp1.1;net452;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net452;net46</TargetFrameworks>
+      
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="LightMock" Version="1.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+      <PackageReference Include="xunit" Version="2.2.0" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
         <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
         <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
         <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
@@ -24,7 +24,5 @@
   </ItemGroup>
 
   
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>   
+  
 </Project>

--- a/src/LightInject.Tests/PropertyInjectionTests.cs
+++ b/src/LightInject.Tests/PropertyInjectionTests.cs
@@ -16,7 +16,7 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.Register<IFoo, FooWithProperyDependency>();
             var instance = (FooWithProperyDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]        
@@ -35,7 +35,7 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.Register(typeof(IFoo<>), typeof(FooWithGenericPropertyDependency<>));
             var instance = (FooWithGenericPropertyDependency<IBar>)container.GetInstance<IFoo<IBar>>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Dependency);
+            Assert.IsAssignableFrom<Bar>(instance.Dependency);
         }
         
         [Fact]
@@ -224,7 +224,7 @@ namespace LightInject.Tests
 
             var result = (FooWithProperyDependency)container.InjectProperties(fooWithProperyDependency);
 
-            Assert.IsAssignableFrom(typeof(Bar), result.Bar);
+            Assert.IsAssignableFrom<Bar>(result.Bar);
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace LightInject.Tests
 
             var result = (FooWithProperyDependency)container.InjectProperties(fooWithProperyDependency);
 
-            Assert.IsAssignableFrom(typeof(Bar), result.Bar);
+            Assert.IsAssignableFrom<Bar>(result.Bar);
         }
 
         [Fact]
@@ -261,7 +261,7 @@ namespace LightInject.Tests
 
             var result = (FooWithProperyDependency)container.InjectProperties(fooWithProperyDependency);
 
-            Assert.IsAssignableFrom(typeof(Bar), result.Bar);
+            Assert.IsAssignableFrom<Bar>(result.Bar);
         }
         [Fact]
         public void InjectProperties_FuncFactory_InjectsPropertyDependencies()
@@ -274,7 +274,7 @@ namespace LightInject.Tests
 
             var result = (FooWithProperyDependency)container.InjectProperties(fooWithProperyDependency);
 
-            Assert.IsAssignableFrom(typeof(Bar), result.Bar);
+            Assert.IsAssignableFrom<Bar>(result.Bar);
         }
 
         [Fact]

--- a/src/LightInject.Tests/PropertySelectorTests.cs
+++ b/src/LightInject.Tests/PropertySelectorTests.cs
@@ -16,7 +16,7 @@ namespace LightInject.Tests
              
             var result = propertySelector.Execute(typeof(FooWithProperyDependency));
 
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace LightInject.Tests
 
             var result = propertySelector.Execute(typeof(FooWithDependency));
 
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace LightInject.Tests
 
             var result = propertySelector.Execute(typeof(FooWithInheritedProperyDepenency));
 
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace LightInject.Tests
 
             var result = propertySelector.Execute(typeof(FooWithStaticProperty));
 
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
         }
     }
 }

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1134,7 +1134,59 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             var canCreateInstance = container.CanGetInstance(typeof(IBar), string.Empty);
             Assert.False(canCreateInstance);
-        }      
+        }
+
+        [Fact]
+        public void CanGetInstance_FuncForKnownService_ReturnsTrue()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void CanGetInstance_FuncForUnknownService_ReturnsFalse()
+        {
+            var container = CreateContainer();            
+            Assert.False(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void CanGetInstance_ExplicitlyRegisteredFunc_ReturnsTrue()
+        {
+            var container = CreateContainer();
+            container.Register<Func<IFoo>>(f => (() => new Foo()));
+            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void CanGetInstance_ParameterizedFuncForKnownService_ReturnsTrue()
+        {
+            var container = CreateContainer();
+            container.Register<int, IFoo>((factory, i) => new FooWithOneParameter(i));
+            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void CanGetInstance_ParameterizedFuncForUnknownService_ReturnsFalse()
+        {
+            var container = CreateContainer();            
+            Assert.False(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+        }
+        [Fact]
+        public void CanGetInstance_LazyForKnownService_ReturnsTrue()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+            Assert.True(container.CanGetInstance(typeof(Lazy<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void CanGetInstance_LazyForUnknownService_ReturnsFalse()
+        {
+            var container = CreateContainer();            
+            Assert.False(container.CanGetInstance(typeof(Lazy<IFoo>), string.Empty));
+        }
 
         [Fact]
         public void GetInstance_RegisterAfterGetInstance_ReturnsDependencyOfSecondRegistration()

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -176,7 +176,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<Foo>();
 
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<Foo>();
 
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo), typeof(Foo));
             object instance = container.GetInstance(typeof(IFoo));
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -241,7 +241,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.Register<IFoo, Foo>("AnotherFoo");
             object instance = container.GetInstance(typeof(IFoo));
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -262,7 +262,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>();
             container.RegisterInstance<IFoo>(new AnotherFoo());
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(AnotherFoo), instance);
+            Assert.IsAssignableFrom<AnotherFoo>(instance);
         }
 
         [Fact]
@@ -281,7 +281,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo), typeof(Foo));
             container.Register(typeof(IFoo), typeof(AnotherFoo), "AnotherFoo");
             object instance = container.GetInstance(typeof(IFoo), "AnotherFoo");
-            Assert.IsAssignableFrom(typeof(AnotherFoo), instance);
+            Assert.IsAssignableFrom<AnotherFoo>(instance);
         }
 
         [Fact]
@@ -292,7 +292,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo), typeof(AnotherFoo), "AnotherFoo");
             container.GetInstance(typeof(IFoo), "AnotherFoo");
             object defaultInstance = container.GetInstance(typeof(IFoo));            
-            Assert.IsAssignableFrom(typeof(Foo), defaultInstance);
+            Assert.IsAssignableFrom<Foo>(defaultInstance);
         }
 
         [Fact]
@@ -301,7 +301,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo), typeof(Foo), "SomeFoo");
             object instance = container.GetInstance(typeof(IFoo));
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -311,7 +311,7 @@ namespace LightInject.Tests
             container.Register<IFoo, Foo>("foo", new PerContainerLifetime());
             container.GetInstance<IFoo>();
             var instances = container.GetAllInstances<IFoo>();
-            Assert.Equal(1, instances.Count());
+            Assert.Single(instances);
         }
 
         [Fact]
@@ -335,7 +335,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo<int>), typeof(Foo<int>), "SomeFoo");
             object instance = container.GetInstance(typeof(IFoo<int>));
-            Assert.IsAssignableFrom(typeof(Foo<int>), instance);
+            Assert.IsAssignableFrom<Foo<int>>(instance);
         }
 
         [Fact]
@@ -344,7 +344,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo), typeof(Foo), "SomeFoo");
             object instance = container.GetInstance<IFoo>("SomeFoo");
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -365,7 +365,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo<>), typeof(Foo<>));
             var instance = container.GetInstance(typeof(IFoo<int>));
-            Assert.IsAssignableFrom(typeof(Foo<int>), instance);
+            Assert.IsAssignableFrom<Foo<int>>(instance);
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(Foo<>));
             container.Register(typeof(IFoo<>), typeof(AnotherFoo<>));
             var instance = container.GetInstance(typeof(IFoo<int>));
-            Assert.IsAssignableFrom(typeof(AnotherFoo<int>), instance);
+            Assert.IsAssignableFrom<AnotherFoo<int>>(instance);
         }
 
         [Fact]
@@ -384,7 +384,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo<>), typeof(Foo<>), "SomeFoo");
             var instance = container.GetInstance(typeof(IFoo<int>));
-            Assert.IsAssignableFrom(typeof(Foo<int>), instance);
+            Assert.IsAssignableFrom<Foo<int>>(instance);
         }
 
         [Fact]
@@ -404,7 +404,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(Foo<>));
             container.Register(typeof(IFoo<string>), typeof(FooWithStringTypeParameter));
             var instance = container.GetInstance(typeof(IFoo<string>));
-            Assert.IsAssignableFrom(typeof(FooWithStringTypeParameter), instance);
+            Assert.IsAssignableFrom<FooWithStringTypeParameter>(instance);
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(Foo<>), "Foo");
             container.Register(typeof(IFoo<string>), typeof(FooWithStringTypeParameter), "FooWithStringTypeParameter");
             var instance = container.GetInstance(typeof(IFoo<string>));
-            Assert.IsAssignableFrom(typeof(FooWithStringTypeParameter), instance);
+            Assert.IsAssignableFrom<FooWithStringTypeParameter>(instance);
         }
 
 
@@ -425,7 +425,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(Foo<>));
             container.Register(typeof(IFoo<>), typeof(AnotherFoo<>), "AnotherFoo");
             var instance = container.GetInstance(typeof(IFoo<int>), "AnotherFoo");
-            Assert.IsAssignableFrom(typeof(AnotherFoo<int>), instance);
+            Assert.IsAssignableFrom<AnotherFoo<int>>(instance);
         }
 
         [Fact]
@@ -435,7 +435,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo<>), typeof(Foo<>), "SomeFoo");
             container.Register(typeof(IFoo<>), typeof(AnotherFoo<>), "AnotherFoo");
             var instance = container.GetInstance(typeof(IFoo<int>), "AnotherFoo");
-            Assert.IsAssignableFrom(typeof(AnotherFoo<int>), instance);
+            Assert.IsAssignableFrom<AnotherFoo<int>>(instance);
         }
 
         [Fact]
@@ -445,7 +445,7 @@ namespace LightInject.Tests
             container.Register(typeof(IBar), typeof(Bar));
             container.Register(typeof(IFoo<>), typeof(FooWithGenericDependency<>));
             var instance = (FooWithGenericDependency<IBar>)container.GetInstance(typeof(IFoo<IBar>));
-            Assert.IsAssignableFrom(typeof(Bar), instance.Dependency);
+            Assert.IsAssignableFrom<Bar>(instance.Dependency);
         }
 
         [Fact]
@@ -520,8 +520,8 @@ namespace LightInject.Tests
             {
                 var intInstance = container.GetInstance<IFoo<int>>();
                 var stringInstance = container.GetInstance<IFoo<string>>();
-                Assert.IsAssignableFrom(typeof(IFoo<int>), intInstance);
-                Assert.IsAssignableFrom(typeof(IFoo<string>), stringInstance);
+                Assert.IsAssignableFrom<IFoo<int>>(intInstance);
+                Assert.IsAssignableFrom<IFoo<string>>(stringInstance);
             }            
         }
 
@@ -637,7 +637,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var factory = container.GetInstance(typeof(Func<IFoo>));
-            Assert.IsAssignableFrom(typeof(Func<IFoo>), factory);
+            Assert.IsAssignableFrom<Func<IFoo>>(factory);
         }
     
 
@@ -646,7 +646,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var factory = container.GetInstance(typeof(Func<string, IFoo>));
-            Assert.IsAssignableFrom(typeof(Func<string, IFoo>), factory);
+            Assert.IsAssignableFrom<Func<string, IFoo>>(factory);
         }
 
         [Fact]
@@ -674,7 +674,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo), typeof(Foo));
             var factory = (Func<IFoo>)container.GetInstance(typeof(Func<IFoo>));
             var instance = factory();
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
         
         [Fact]
@@ -749,7 +749,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register<IFoo>(c => new Foo());
             var instance = container.GetInstance(typeof(IFoo));
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
     
         [Fact]
@@ -759,7 +759,7 @@ namespace LightInject.Tests
             container.Register<IFoo>(c => new FooWithMultipleConstructors());
             container.Register<IFoo>(c => new FooWithMultipleConstructors(new Bar()));
             var instance = (FooWithMultipleConstructors)container.GetInstance(typeof(IFoo));            
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -768,7 +768,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register<IFoo>(c => new Foo(), "SomeFoo");
             var instance = container.GetInstance(typeof(IFoo), "SomeFoo");
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -788,7 +788,7 @@ namespace LightInject.Tests
             container.Register<IBar>(c => new Bar());
             container.Register<IFoo>(c => new FooWithDependency(c.GetInstance<IBar>()));
             var instance = (FooWithDependency)container.GetInstance(typeof(IFoo));
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -856,7 +856,7 @@ namespace LightInject.Tests
            
             container.Register<IFoo>(factory => new FooWithArrayDependency(new[] { factory.GetInstance<IBar>() }));
             var instance = (FooWithArrayDependency)container.GetInstance<IFoo>();
-            Assert.Equal(1, instance.Bars.Count());
+            Assert.Single(instance.Bars);
         }
 
         [Fact]
@@ -867,7 +867,7 @@ namespace LightInject.Tests
 
             container.Register<IFoo>(factory => new FooWithParamsArrayDependency(new[] { factory.GetInstance<IBar>() }));
             var instance = (FooWithParamsArrayDependency)container.GetInstance<IFoo>();
-            Assert.Equal(1, instance.Bars.Count());
+            Assert.Single(instance.Bars);
         }
 
         [Fact]
@@ -920,7 +920,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var instances = container.GetAllInstances<IFoo>();
-            Assert.IsAssignableFrom(typeof(IEnumerable<IFoo>), instances);
+            Assert.IsAssignableFrom<IEnumerable<IFoo>>(instances);
         }
 
         [Fact]
@@ -961,7 +961,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo), typeof(Foo));
             container.Register(typeof(IFoo), typeof(AnotherFoo), "AnotherFoo");
             var instances = container.GetAllInstances(typeof(IFoo));
-            Assert.IsAssignableFrom(typeof(IEnumerable<IFoo>), instances);
+            Assert.IsAssignableFrom<IEnumerable<IFoo>>(instances);
         }
 
         [Fact]
@@ -971,7 +971,7 @@ namespace LightInject.Tests
             container.Register(typeof(IFoo), typeof(Foo));
             container.Register(typeof(IFoo), typeof(AnotherFoo), "AnotherFoo");
             var instances = container.GetAllInstances<IFoo>();
-            Assert.IsAssignableFrom(typeof(IEnumerable<IFoo>), instances);
+            Assert.IsAssignableFrom<IEnumerable<IFoo>>(instances);
         }
 
         [Fact]
@@ -1056,7 +1056,7 @@ namespace LightInject.Tests
             container.Register<Foo>();
             container.Register<DerivedFoo>();
             var instances = container.GetAllInstances<Foo>();
-            Assert.Equal(1, instances.Count());
+            Assert.Single(instances);
         }
 
         [Fact]
@@ -1065,7 +1065,7 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.RegisterFallback((serviceType, serviceName) => serviceType == typeof(IFoo), request => new Foo());
             var instance = container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(IFoo), instance);
+            Assert.IsAssignableFrom<IFoo>(instance);
         }
 
         [Fact]
@@ -1101,8 +1101,8 @@ namespace LightInject.Tests
             container.RegisterFallback((serviceType, serviceName) => true, request => Activator.CreateInstance(request.ServiceType), new PerContainerLifetime());
             var foo = container.GetInstance(typeof(Foo));
             var bar = container.GetInstance(typeof(Bar));            
-            Assert.IsAssignableFrom(typeof(Foo), foo);
-            Assert.IsAssignableFrom(typeof(Bar), bar);
+            Assert.IsAssignableFrom<Foo>(foo);
+            Assert.IsAssignableFrom<Bar>(bar);
         }
 
         [Fact]
@@ -1238,7 +1238,7 @@ namespace LightInject.Tests
             catch (Exception)
             {
                 var exception = Assert.Throws<InvalidOperationException>(() => container.GetInstance<IFoo>());
-                Assert.False(exception.InnerException.Message.Contains("Recursive"));                
+                Assert.DoesNotContain("Recursive", exception.InnerException.Message);                
             }
         }
 
@@ -1394,7 +1394,7 @@ namespace LightInject.Tests
 
             var instance = container.TryGetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -1414,7 +1414,7 @@ namespace LightInject.Tests
 
             var lazyInstance = container.GetInstance<Lazy<IFoo>>();
 
-            Assert.IsAssignableFrom(typeof(Lazy<IFoo>), lazyInstance);
+            Assert.IsAssignableFrom<Lazy<IFoo>>(lazyInstance);
         }
 
         [Fact]
@@ -1435,7 +1435,7 @@ namespace LightInject.Tests
             
             var instance = container.GetInstance<Lazy<IFoo>>();
 
-            Assert.IsAssignableFrom(typeof(Foo), instance.Value);
+            Assert.IsAssignableFrom<Foo>(instance.Value);
         }
 
         [Fact]
@@ -1448,7 +1448,7 @@ namespace LightInject.Tests
             var factory = container.GetInstance<IFooFactory>();
             var instance = factory.CreateFoo();
 
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -1482,7 +1482,7 @@ namespace LightInject.Tests
 
             var instances = container.GetAllInstances<IFoo<int>>();
             
-            Assert.Equal(1, instances.Count());
+            Assert.Single(instances);
         }
        
         [Fact]
@@ -1502,7 +1502,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var instance = container.Create<Foo>();
-            Assert.IsAssignableFrom(typeof(Foo), instance);
+            Assert.IsAssignableFrom<Foo>(instance);
         }
 
         [Fact]
@@ -1510,7 +1510,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             var instance = container.Create(typeof(Foo));
-            Assert.IsAssignableFrom(typeof(Foo), instance);            
+            Assert.IsAssignableFrom<Foo>(instance);            
         }
 
         [Fact]
@@ -1526,7 +1526,7 @@ namespace LightInject.Tests
                 null);
 
             var instance = container.GetInstance<Foo>();
-            Assert.IsAssignableFrom(typeof(Foo), instance);   
+            Assert.IsAssignableFrom<Foo>(instance);   
         }
 
         [Fact]
@@ -1536,7 +1536,7 @@ namespace LightInject.Tests
             container.Register<IFoo, FooWithDependency>();
             container.RegisterConstructorDependency<IBar>((factory, info) => new Bar());
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1547,7 +1547,7 @@ namespace LightInject.Tests
             container.RegisterConstructorDependency<IBar>((factory, info) => new Bar());
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
             container.RegisterConstructorDependency<IBar>((factory, info) => new AnotherBar());
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1558,7 +1558,7 @@ namespace LightInject.Tests
             container.RegisterConstructorDependency<IBar>((factory, info) => new Bar());            
             container.RegisterConstructorDependency<IBar>((factory, info) => new AnotherBar());
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(AnotherBar), instance.Bar);
+            Assert.IsAssignableFrom<AnotherBar>(instance.Bar);
         }
 
         [Fact]
@@ -1569,7 +1569,7 @@ namespace LightInject.Tests
             container.RegisterConstructorDependency<IBar>((factory, info, args) => new Bar());
             container.RegisterConstructorDependency<IBar>((factory, info, args) => new AnotherBar());
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(AnotherBar), instance.Bar);
+            Assert.IsAssignableFrom<AnotherBar>(instance.Bar);
         }
 
         [Fact]
@@ -1579,7 +1579,7 @@ namespace LightInject.Tests
             container.Register<IFoo, FooWithDependency>();
             container.RegisterConstructorDependency<IBar>((factory, info, arguments ) => (Bar)arguments[0]);
             var instance = (FooWithDependency)container.GetInstance<IBar, IFoo>(new Bar());
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1590,7 +1590,7 @@ namespace LightInject.Tests
             container.Register<IBar, AnotherBar>();
             container.RegisterConstructorDependency<IBar>((factory, info, arguments) => (Bar)arguments[0]);
             var instance = (FooWithDependency)container.GetInstance<IBar, IFoo>(new Bar());
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
        
         [Fact]
@@ -1617,7 +1617,7 @@ namespace LightInject.Tests
                 return new Bar();
             });
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
 
@@ -1654,7 +1654,7 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.RegisterConstructorDependency((factory, info, arguments) => factory.GetInstance<IBar>());
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1664,7 +1664,7 @@ namespace LightInject.Tests
             container.Register<IFoo, FooWithProperyDependency>();
             container.RegisterPropertyDependency<IBar>((factory, info) => new Bar());
             var instance = (FooWithProperyDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1675,7 +1675,7 @@ namespace LightInject.Tests
             container.RegisterPropertyDependency<IBar>((factory, info) => new Bar());
             var instance = (FooWithProperyDependency)container.GetInstance<IFoo>();
             container.RegisterPropertyDependency<IBar>((factory, info) => new AnotherBar());
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1686,7 +1686,7 @@ namespace LightInject.Tests
             container.RegisterPropertyDependency<IBar>((factory, info) => new Bar());
             container.RegisterPropertyDependency<IBar>((factory, info) => new AnotherBar());
             var instance = (FooWithProperyDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(AnotherBar), instance.Bar);
+            Assert.IsAssignableFrom<AnotherBar>(instance.Bar);
         }
 
         [Fact]
@@ -1697,7 +1697,7 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.RegisterPropertyDependency((factory, info) => factory.GetInstance<IBar>());
             var instance = (FooWithProperyDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1708,7 +1708,7 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>();
             container.RegisterConstructorDependency((factory, info) => factory.GetInstance<IBar>());
             var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), instance.Bar);
+            Assert.IsAssignableFrom<Bar>(instance.Bar);
         }
 
         [Fact]
@@ -1720,7 +1720,7 @@ namespace LightInject.Tests
                 registration => true,
                 (factory, instance) => ((FooWithProperyDependency)instance).Bar = new Bar());
             var foo = (FooWithProperyDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom(typeof(Bar), foo.Bar);
+            Assert.IsAssignableFrom<Bar>(foo.Bar);
         }
 
         

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -698,8 +698,13 @@ namespace LightInject.Tests
             var instance2 = factory();
             Assert.NotSame(instance1, instance2);
         }
-  
-        
+
+        //[Fact]
+        //public void GetInstance_Func_FailesWhenUnderlyingServiceIsMissing()
+        //{
+        //    var container = CreateContainer(new ContainerOptions(){EnableStrictDeferredResolution = true});
+        //    Assert.Throws<InvalidOperationException>(() => container.GetInstance<Func<IFoo>>());
+        //}
 
         #endregion
         #region Func Factory

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1828,6 +1828,14 @@ namespace LightInject.Tests
             Assert.IsType<Bar>(container.GetInstance<IBar>());
         }
 
+        [Fact]
+        public void ShouldBeAbleToCloneContainer()
+        {
+            var container = new ServiceContainer();
+            var clonedContainer = container.Clone();
+            Assert.IsType<ServiceContainer>(clonedContainer);
+        }
+
         #region Internal Classes
 
         [Fact]

--- a/src/LightInject.Tests/ServiceRegistrationTests.cs
+++ b/src/LightInject.Tests/ServiceRegistrationTests.cs
@@ -78,7 +78,7 @@ namespace LightInject.Tests
 
             var instance = container.GetInstance<IFoo>();
 
-            Assert.IsAssignableFrom(typeof(AnotherFoo), instance);
+            Assert.IsAssignableFrom<AnotherFoo>(instance);
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace LightInject.Tests
                 container.Register<IFoo, Foo>();
                 container.GetInstance<IFoo>();
                 container.Register<IFoo, Foo>();
-                Assert.True(message.StartsWith("Cannot overwrite existing serviceregistration"));
+                Assert.StartsWith("Cannot overwrite existing serviceregistration", message);
             }
             finally
             {

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1932,6 +1932,26 @@ namespace LightInject
 #endif
         }
 
+        private ServiceContainer(
+            ContainerOptions options,
+            ServiceRegistry<Delegate> constructorDependencyFactories,
+            ServiceRegistry<Delegate> propertyDependencyFactories,
+            ServiceRegistry<ServiceRegistration> availableServices,
+            Storage<DecoratorRegistration> decorators,
+            Storage<ServiceOverride> overrides,
+            Storage<FactoryRule> factoryRules,
+            Storage<Initializer> initializers)
+        {
+            this.options = options;
+            this.constructorDependencyFactories = constructorDependencyFactories;
+            this.propertyDependencyFactories = propertyDependencyFactories;
+            this.availableServices = availableServices;
+            this.decorators = decorators;
+            this.overrides = overrides;
+            this.factoryRules = factoryRules;
+            this.initializers = initializers;
+        }
+
         /// <summary>
         /// Gets or sets the <see cref="IScopeManagerProvider"/> that is responsible
         /// for providing the <see cref="IScopeManager"/> used to manage scopes.
@@ -2903,6 +2923,23 @@ namespace LightInject
             {
                 disposableLifetimeInstance.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Creates a clone of the current <see cref="ServiceContainer"/>.
+        /// </summary>
+        /// <returns>A new <see cref="ServiceContainer"/> instance.</returns>
+        public ServiceContainer Clone()
+        {
+            return new ServiceContainer(
+                options,
+                constructorDependencyFactories,
+                propertyDependencyFactories,
+                availableServices,
+                decorators,
+                overrides,
+                factoryRules,
+                initializers);
         }
 
         private static void EmitNewArray(IList<Action<IEmitter>> emitMethods, Type elementType, IEmitter emitter)

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2007,6 +2007,11 @@ namespace LightInject
         /// <returns><b>true</b> if the container can create the requested service, otherwise <b>false</b>.</returns>
         public bool CanGetInstance(Type serviceType, string serviceName)
         {
+            if (serviceType.IsFunc() || serviceType.IsFuncWithParameters() || serviceType.IsLazy())
+            {
+                var returnType = serviceType.GenericTypeArguments.Last();                
+                return GetEmitMethod(returnType, serviceName) != null || availableServices.ContainsKey(serviceType);
+            }
             return GetEmitMethod(serviceType, serviceName) != null;
         }
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -21,7 +21,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ******************************************************************************
-    LightInject version 5.0.4
+    LightInject version 5.1.0
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard1.6;net452;net46</TargetFrameworks>
+    <TargetFrameworks>;net46;netstandard1.1;netstandard1.3;netstandard1.6;net452</TargetFrameworks>
     <Version>5.0.4</Version>
     <Authors>Bernhard Richter</Authors>   
     <PackageProjectUrl>http//www.lightinject.net</PackageProjectUrl>

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>;net46;netstandard1.1;netstandard1.3;netstandard1.6;net452</TargetFrameworks>
-    <Version>5.0.4</Version>
+    <Version>5.1.0</Version>
     <Authors>Bernhard Richter</Authors>   
     <PackageProjectUrl>http//www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR adds sanity checks for deferred service resolution. 
By deferred resolution we mean injection one of the following.

* Func&lt;IFoo&gt;
* Func&lt;int,IFoo&gt; (function delegate with runtime arguments)
* Lazy&lt;IFoo&gt;

The CanGetInstance method now checks if it can resolve the return type before reporting whether it can resolve either of these types. 

We also bring back the Clone method as requested in #372 

The PCL targets has been removed and we only publish the following target frameworks

* NETSTANDARD 1.1
* NETSTANDARD 1.3
* NETSTANDARD 1.6
* NET45
* NET46

