### PR TITLE
Deterministic ordering when resolving IEnumerable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,59 @@ This behavior can be overridden using the **EnableVariance** container option.
 	var instances = container.GetAllInstances<Foo>();
 	Assert.AreEqual(1, instances.Count());
 
+
+
+#### Ordering
+
+Sometimes the ordering of the resolved services are important and **LightInject** solves this by ordering services by their service name.
+
+```c#
+container.Register<IFoo, Foo1>("A");
+container.Register<IFoo, Foo2>("B");
+container.Register<IFoo, Foo3>("C");
+
+var instances = container.GetAllInstances<IFoo>().ToArray();
+Assert.IsType<Foo1>(instances[0]);
+Assert.IsType<Foo2>(instances[1]);
+Assert.IsType<Foo3>(instances[2]);
+```
+
+We can also register multiple implementations for a given service type using the `RegisterOrdered` method.
+
+```c#
+var container = CreateContainer();
+container.RegisterOrdered(typeof(IFoo), new[] {typeof(Foo1), typeof(Foo2), typeof(Foo3)},
+    type => new PerContainerLifetime());
+
+var instances = container.GetAllInstances<IFoo>().ToArray();
+
+Assert.IsType<Foo1>(instances[0]);
+Assert.IsType<Foo2>(instances[1]);
+Assert.IsType<Foo3>(instances[2]);
+```
+
+The `RegisterOrdered` method gives each implementation a service name that can be used for ordering when resolving these services. By default the service name is formatted like `001`, `002` and so on. 
+If we need so change this convention, we can do this by passing a format function to the `RegisterOrdered` method.
+
+```c#
+container.RegisterOrdered(typeof(IFoo<>), new[] { typeof(Foo1<>), typeof(Foo2<>), typeof(Foo3<>) },
+    type => new PerContainerLifetime(), i => $"A{i.ToString().PadLeft(3,'0')}");
+
+var services = container.AvailableServices.Where(sr => sr.ServiceType == typeof(IFoo<>))
+    .OrderBy(sr => sr.ServiceName).ToArray();
+Assert.Equal("A001", services[0].ServiceName);
+Assert.Equal("A002", services[1].ServiceName);
+Assert.Equal("A003", services[2].ServiceName);
+```
+
+
+
+
+
+
+
+
+
 ### Values ###
 
 Registers the value as a constant.

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -151,7 +151,13 @@ namespace LightInject.Tests
             throw new NotImplementedException();
         }
 
-        public IServiceRegistry RegisteredOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifetimeFactory)
+        public IServiceRegistry RegisterOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifetimeFactory)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IServiceRegistry RegisterOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifeTimeFactory,
+            Func<int, string> serviceNameFormatter)
         {
             throw new NotImplementedException();
         }

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -151,6 +151,11 @@ namespace LightInject.Tests
             throw new NotImplementedException();
         }
 
+        public IServiceRegistry RegisteredOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifetimeFactory)
+        {
+            throw new NotImplementedException();
+        }
+
         public IServiceRegistry RegisterFallback(Func<Type, string, bool> predicate, Func<ServiceRequest, object> factory)
         {
             throw new NotImplementedException();

--- a/src/LightInject.Tests/OrderedTests.cs
+++ b/src/LightInject.Tests/OrderedTests.cs
@@ -34,11 +34,44 @@ namespace LightInject.Tests
             Assert.IsType<Foo3>(instances[2]);
         }
 
+        [Fact]
+        public void ShouldOrderServicesWhenRegisteredAsOrdered()
+        {
+            var container = CreateContainer();
+            container.RegisteredOrdered(typeof(IFoo), new[] {typeof(Foo1), typeof(Foo2), typeof(Foo3)},
+                type => new PerContainerLifetime());
+
+            var instances = container.GetAllInstances<IFoo>().ToArray();
+
+            Assert.IsType<Foo1>(instances[0]);
+            Assert.IsType<Foo2>(instances[1]);
+            Assert.IsType<Foo3>(instances[2]);
+        }
+
+        [Fact]
+        public void ShouldOrderOpenGenericServicesWhenRegisteredAsOrdered()
+        {
+            var container = CreateContainer();
+            container.RegisteredOrdered(typeof(IFoo<>), new[] { typeof(Foo1<>), typeof(Foo2<>), typeof(Foo3<>) },
+                type => new PerContainerLifetime());
+
+            var instances = container.GetAllInstances<IFoo<int>>().ToArray();
+            Assert.IsType<Foo1<int>>(instances[0]);
+            Assert.IsType<Foo2<int>>(instances[1]);
+            Assert.IsType<Foo3<int>>(instances[2]);            
+        }
+
         public class Foo1 : IFoo { }
 
         public class Foo2 : IFoo { }
 
         public class Foo3 : IFoo { }
+
+        public class Foo1<T> : IFoo<T> { }
+
+        public class Foo2<T> : IFoo<T> { }
+
+        public class Foo3<T> : IFoo<T> { }
     }
 
 

--- a/src/LightInject.Tests/OrderedTests.cs
+++ b/src/LightInject.Tests/OrderedTests.cs
@@ -38,7 +38,7 @@ namespace LightInject.Tests
         public void ShouldOrderServicesWhenRegisteredAsOrdered()
         {
             var container = CreateContainer();
-            container.RegisteredOrdered(typeof(IFoo), new[] {typeof(Foo1), typeof(Foo2), typeof(Foo3)},
+            container.RegisterOrdered(typeof(IFoo), new[] {typeof(Foo1), typeof(Foo2), typeof(Foo3)},
                 type => new PerContainerLifetime());
 
             var instances = container.GetAllInstances<IFoo>().ToArray();
@@ -52,13 +52,27 @@ namespace LightInject.Tests
         public void ShouldOrderOpenGenericServicesWhenRegisteredAsOrdered()
         {
             var container = CreateContainer();
-            container.RegisteredOrdered(typeof(IFoo<>), new[] { typeof(Foo1<>), typeof(Foo2<>), typeof(Foo3<>) },
+            container.RegisterOrdered(typeof(IFoo<>), new[] { typeof(Foo1<>), typeof(Foo2<>), typeof(Foo3<>) },
                 type => new PerContainerLifetime());
 
             var instances = container.GetAllInstances<IFoo<int>>().ToArray();
             Assert.IsType<Foo1<int>>(instances[0]);
             Assert.IsType<Foo2<int>>(instances[1]);
             Assert.IsType<Foo3<int>>(instances[2]);            
+        }
+
+        [Fact]
+        public void ShouldUseCustomServiceNameFormatter()
+        {
+            var container = CreateContainer();
+            container.RegisterOrdered(typeof(IFoo<>), new[] { typeof(Foo1<>), typeof(Foo2<>), typeof(Foo3<>) },
+                type => new PerContainerLifetime(), i => $"A{i.ToString().PadLeft(3,'0')}");
+
+            var services = container.AvailableServices.Where(sr => sr.ServiceType == typeof(IFoo<>))
+                .OrderBy(sr => sr.ServiceName).ToArray();
+            Assert.Equal("A001", services[0].ServiceName);
+            Assert.Equal("A002", services[1].ServiceName);
+            Assert.Equal("A003", services[2].ServiceName);
         }
 
         public class Foo1 : IFoo { }

--- a/src/LightInject.Tests/OrderedTests.cs
+++ b/src/LightInject.Tests/OrderedTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Linq;
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests
+{
+    public class OrderedTests : TestBase
+    {
+        [Fact]
+        public void ShouldOrderServicesByName()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo1>("A");
+            container.Register<IFoo, Foo2>("B");
+            container.Register<IFoo, Foo3>("C");
+
+            var instances = container.GetAllInstances<IFoo>().ToArray();
+            Assert.IsType<Foo1>(instances[0]);
+            Assert.IsType<Foo2>(instances[1]);
+            Assert.IsType<Foo3>(instances[2]);
+        }
+
+        [Fact]
+        public void ShouldOrderServicesByNameWithVarianceDisabled()
+        {
+            var container = CreateContainer(new ContainerOptions { EnableVariance = false });
+            container.Register<IFoo, Foo1>("A");
+            container.Register<IFoo, Foo2>("B");
+            container.Register<IFoo, Foo3>("C");
+
+            var instances = container.GetAllInstances<IFoo>().ToArray();
+            Assert.IsType<Foo1>(instances[0]);
+            Assert.IsType<Foo2>(instances[1]);
+            Assert.IsType<Foo3>(instances[2]);
+        }
+
+        public class Foo1 : IFoo { }
+
+        public class Foo2 : IFoo { }
+
+        public class Foo3 : IFoo { }
+    }
+
+
+  
+}

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -374,7 +374,19 @@ namespace LightInject
         /// <param name="implementingTypes">The implementing types.</param>
         /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of each entry in <paramref name="implementingTypes"/>.</param>
         /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
-        IServiceRegistry RegisteredOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifetimeFactory);
+        IServiceRegistry RegisterOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifetimeFactory);
+
+        /// <summary>
+        /// Registers the <paramref name="serviceType"/> with a set of <paramref name="implementingTypes"/> and
+        /// ensures that service instance ordering matches the ordering of the <paramref name="implementingTypes"/>. 
+        /// </summary>
+        /// <param name="serviceType">The service type to register.</param>
+        /// <param name="implementingTypes">The implementing types.</param>
+        /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of each entry in <paramref name="implementingTypes"/>.</param>
+        /// <param name="serviceNameFormatter">The function used to format the service name based on current registration index.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        IServiceRegistry RegisterOrdered(Type serviceType, Type[] implementingTypes,
+            Func<Type, ILifetime> lifeTimeFactory, Func<int, string> serviceNameFormatter);
 
         /// <summary>
         /// Registers a custom factory delegate used to create services that is otherwise unknown to the service container.
@@ -4063,13 +4075,36 @@ namespace LightInject
             Register(serviceRegistration);
         }
 
-        public IServiceRegistry RegisteredOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifeTimeFactory)
+        /// <summary>
+        /// Registers the <paramref name="serviceType"/> with a set of <paramref name="implementingTypes"/> and
+        /// ensures that service instance ordering matches the ordering of the <paramref name="implementingTypes"/>. 
+        /// </summary>
+        /// <param name="serviceType">The service type to register.</param>
+        /// <param name="implementingTypes">The implementing types.</param>
+        /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of each entry in <paramref name="implementingTypes"/>.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public IServiceRegistry RegisterOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifeTimeFactory)
+        {
+            return RegisterOrdered(serviceType, implementingTypes, lifeTimeFactory, i => i.ToString().PadLeft(3, '0'));
+        }
+
+        /// <summary>
+        /// Registers the <paramref name="serviceType"/> with a set of <paramref name="implementingTypes"/> and
+        /// ensures that service instance ordering matches the ordering of the <paramref name="implementingTypes"/>. 
+        /// </summary>
+        /// <param name="serviceType">The service type to register.</param>
+        /// <param name="implementingTypes">The implementing types.</param>
+        /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of each entry in <paramref name="implementingTypes"/>.</param>
+        /// <param name="serviceNameFormatter">The function used to format the service name based on current registration index.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public IServiceRegistry RegisterOrdered(Type serviceType, Type[] implementingTypes,
+            Func<Type, ILifetime> lifeTimeFactory, Func<int, string> serviceNameFormatter)
         {
             var offset = GetAvailableServices(serviceType).Count;
             foreach (var implementingType in implementingTypes)
             {
-                offset++;
-                Register(serviceType, implementingType,offset.ToString(), lifeTimeFactory(implementingType));
+                offset++;                
+                Register(serviceType, implementingType, serviceNameFormatter(offset), lifeTimeFactory(implementingType));
             }
 
             return this;

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -3839,11 +3839,14 @@ namespace LightInject
 
             if (options.EnableVariance)
             {
-                emitMethods = emitters.Where(kv => actualServiceType.GetTypeInfo().IsAssignableFrom(kv.Key.GetTypeInfo())).SelectMany(kv => kv.Value.Values).ToList();
+                emitMethods = emitters
+                    .Where(kv => actualServiceType.GetTypeInfo().IsAssignableFrom(kv.Key.GetTypeInfo()))
+                    .SelectMany(kv => kv.Value).OrderBy(kv => kv.Key).Select(kv => kv.Value)
+                    .ToList();                
             }
             else
             {
-                emitMethods = GetEmitMethods(actualServiceType).Values.ToList();
+                emitMethods = GetEmitMethods(actualServiceType).OrderBy(kv => kv.Key).Select(kv => kv.Value).ToList();                
             }
 
             if (dependencyStack.Count > 0 && emitMethods.Contains(dependencyStack.Peek()))

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -367,6 +367,16 @@ namespace LightInject
         IServiceRegistry Register<TService>(Func<IServiceFactory, TService> factory, string serviceName, ILifetime lifetime);
 
         /// <summary>
+        /// Registers the <paramref name="serviceType"/> with a set of <paramref name="implementingTypes"/> and
+        /// ensures that service instance ordering matches the ordering of the <paramref name="implementingTypes"/>. 
+        /// </summary>
+        /// <param name="serviceType">The service type to register.</param>
+        /// <param name="implementingTypes">The implementing types.</param>
+        /// <param name="lifetimeFactory">The <see cref="ILifetime"/> factory that controls the lifetime of each entry in <paramref name="implementingTypes"/>.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        IServiceRegistry RegisteredOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifetimeFactory);
+
+        /// <summary>
         /// Registers a custom factory delegate used to create services that is otherwise unknown to the service container.
         /// </summary>
         /// <param name="predicate">Determines if the service can be created by the <paramref name="factory"/> delegate.</param>
@@ -4051,6 +4061,18 @@ namespace LightInject
                 Lifetime = lifetime ?? DefaultLifetime,
             };
             Register(serviceRegistration);
+        }
+
+        public IServiceRegistry RegisteredOrdered(Type serviceType, Type[] implementingTypes, Func<Type, ILifetime> lifeTimeFactory)
+        {
+            var offset = GetAvailableServices(serviceType).Count;
+            foreach (var implementingType in implementingTypes)
+            {
+                offset++;
+                Register(serviceType, implementingType,offset.ToString(), lifeTimeFactory(implementingType));
+            }
+
+            return this;
         }
 
         private class Storage<T>


### PR DESCRIPTION
This PR adds support for deterministic ordering when resolving multiple services through an `IEnumerable<T>`