### PR TITLE
Feature/Compilation

### DIFF
--- a/src/LightInject.Tests/CompilationTests.cs
+++ b/src/LightInject.Tests/CompilationTests.cs
@@ -1,0 +1,120 @@
+﻿using LightInject.SampleLibrary;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace LightInject.Tests
+{
+    public class CompilationTests
+    {
+        [Fact]
+        public void ShouldCompileServices()
+        {
+            var options = new ContainerOptions();
+            var log = new List<LogEntry>();
+            options.LogFactory = (type) => (e) => log.Add(e);
+            var container = new ServiceContainer(options);
+
+            container.Register<IBar, Bar>();
+            container.Register<IFoo, FooWithDependency>();
+            container.Compile();
+
+            Assert.Contains(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IBar"));
+            Assert.Contains(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IFoo"));            
+
+            log.Clear();
+            container.GetInstance<IFoo>();
+            Assert.DoesNotContain(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IBar"));
+            Assert.DoesNotContain(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IFoo"));
+        }
+
+        [Fact]
+        public void ShouldLogWarningWhenCompileOpenGenericService()
+        {
+            var options = new ContainerOptions();
+            var log = new List<LogEntry>();
+            options.LogFactory = (type) => (e) => log.Add(e);
+            var container = new ServiceContainer(options);
+
+            container.Register(typeof(OpenGenericFoo<,>));            
+            container.Compile();
+
+            Assert.Contains(log, e => e.Level == LogLevel.Warning && e.Message.Matches("Unable to precompile.*OpenGenericFoo"));
+        }
+
+        [Fact]
+        public void ShouldCompileOpenGenericService()
+        {
+            var options = new ContainerOptions();
+            var log = new List<LogEntry>();
+            options.LogFactory = (type) => (e) => log.Add(e);
+            var container = new ServiceContainer(options);
+
+            container.Register(typeof(OpenGenericFoo<,>));
+
+            container.Compile<OpenGenericFoo<string, int>>();
+
+            log.Clear();
+
+            container.GetInstance<OpenGenericFoo<string, int>>();
+
+            Assert.DoesNotContain(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*OpenGenericFoo"));
+        }
+
+        [Fact]
+        public void ShouldCompileNamedService()
+        {
+            var options = new ContainerOptions();
+            var log = new List<LogEntry>();
+            options.LogFactory = (type) => (e) => log.Add(e);
+            var container = new ServiceContainer(options);
+
+            container.Register<IFoo, Foo>("SomeFoo");            
+            container.Compile();
+
+            Assert.Contains(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IFoo.*SomeFoo"));
+           
+            log.Clear();
+            container.GetInstance<IFoo>();
+            Assert.DoesNotContain(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IFoo.*SomeFoo"));
+        }
+
+
+        [Fact]
+        public void ShouldCompileNamedOpenGenericService()
+        {
+            var options = new ContainerOptions();
+            var log = new List<LogEntry>();
+            options.LogFactory = (type) => (e) => log.Add(e);
+            var container = new ServiceContainer(options);
+
+            container.Register(typeof(OpenGenericFoo<,>), typeof(OpenGenericFoo<,>), "OpenGenericFoo");
+
+            container.Compile<OpenGenericFoo<string, int>>("OpenGenericFoo");
+
+            log.Clear();
+
+            container.GetInstance<OpenGenericFoo<string, int>>("OpenGenericFoo");
+
+            Assert.DoesNotContain(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*OpenGenericFoo"));
+        }
+
+
+        [Fact]
+        public void ShouldCompileServicesAccordingToPredicate()
+        {
+            var options = new ContainerOptions();
+            var log = new List<LogEntry>();
+            options.LogFactory = (type) => (e) => log.Add(e);
+            var container = new ServiceContainer(options);
+
+            container.Register<IBar, Bar>();
+            container.Register<IFoo, FooWithDependency>();
+            container.Compile(sr => sr.ServiceType == typeof(IBar));
+
+            Assert.Contains(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IBar"));
+            Assert.DoesNotContain(log, e => e.Level == LogLevel.Info && e.Message.Matches("Compiling delegate.*IFoo"));
+        }        
+    }
+}

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -404,5 +404,25 @@ namespace LightInject.Tests
         {
             throw new NotImplementedException();
         }
+
+        public void Compile(Func<ServiceRegistration, bool> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Compile()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Compile(Type serviceType, string serviceName = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Compile<TService>(string serviceType = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.0;net452;net46</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netcoreapp2.0</TargetFrameworks>
       
   </PropertyGroup>
 
@@ -10,9 +10,9 @@
     
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-      <PackageReference Include="xunit" Version="2.3.0" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+      <PackageReference Include="xunit" Version="2.3.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
         <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />

--- a/src/LightInject.Tests/StringExtensions.cs
+++ b/src/LightInject.Tests/StringExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace LightInject.Tests
+{
+    public static class StringExtensions
+    {
+        public static bool Matches(this String s, string pattern, bool ignoreCase = true)
+        {
+            if (ignoreCase)
+            {
+                return ((Regex.IsMatch(s, pattern, RegexOptions.IgnoreCase))) ? true : false;
+            }
+            else
+            {
+                return (Regex.IsMatch(s, pattern)) ? true : false;
+            }
+        }
+    }
+}

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4171,6 +4171,10 @@ namespace LightInject
             return this;
         }
 
+        /// <summary>
+        /// Compiles services that matches the given <paramref name="predicate"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate that determines if a service should be compiled.</param>
         public void Compile(Func<ServiceRegistration, bool> predicate)
         {            
             var rootServices = AvailableServices.Where(predicate).ToArray();
@@ -4203,11 +4207,20 @@ namespace LightInject
             }
         }
 
+        /// <summary>
+        /// Compiles all registered services. 
+        /// </summary>    
         public void Compile()
         {
             Compile(sr => true);
         }
 
+        /// <summary>
+        /// Compiles the service identified by <typeparamref name="TService"/>
+        /// and optionally the <paramref name="serviceName"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to be compiled.</typeparam>
+        /// <param name="serviceType">The service type to be compiled.</param>
         public void Compile<TService>(string serviceName = null)
         {
             if (string.IsNullOrWhiteSpace(serviceName))

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -691,8 +691,26 @@ namespace LightInject
         /// <param name="instance">The target instance for which to inject its property dependencies.</param>
         /// <returns>The <paramref name="instance"/> with its property dependencies injected.</returns>
         object InjectProperties(object instance);
-    }
 
+        /// <summary>
+        /// Compiles all registered services. 
+        /// </summary>        
+        void Compile();
+
+        /// <summary>
+        /// Compiles services that matches the given <paramref name="predicate"/>.
+        /// </summary>
+        /// <param name="predicate">The predicate that determines if a service should be compiled.</param>
+        void Compile(Func<ServiceRegistration, bool> predicate);
+               
+        /// <summary>
+        /// Compiles the service identified by <typeparamref name="TService"/>
+        /// and optionally the <paramref name="serviceName"/>.
+        /// </summary>
+        /// <typeparam name="TService">The service type to be compiled.</typeparam>
+        /// <param name="serviceType">The service type to be compiled.</param>
+        void Compile<TService>(string serviceName = null);
+    }
     /// <summary>
     /// Represents a class that manages the lifetime of a service instance.
     /// </summary>
@@ -4040,6 +4058,7 @@ namespace LightInject
 
         private GetInstanceDelegate CreateDefaultDelegate(Type serviceType, bool throwError)
         {
+            log.Info($"Compiling delegate for resolving service : {serviceType}");
             var instanceDelegate = CreateDelegate(serviceType, string.Empty, throwError);
             if (instanceDelegate == null)
             {
@@ -4052,6 +4071,7 @@ namespace LightInject
 
         private GetInstanceDelegate CreateNamedDelegate(Tuple<Type, string> key, bool throwError)
         {
+            log.Info($"Compiling delegate for resolving service : {key.Item1}, name: {key.Item2}");
             var instanceDelegate = CreateDelegate(key.Item1, key.Item2, throwError);
             if (instanceDelegate == null)
             {
@@ -4149,6 +4169,55 @@ namespace LightInject
             }
 
             return this;
+        }
+
+        public void Compile(Func<ServiceRegistration, bool> predicate)
+        {            
+            var rootServices = AvailableServices.Where(predicate).ToArray();
+            foreach (var rootService in rootServices)
+            {
+                if (rootService.ServiceType.GetTypeInfo().IsGenericTypeDefinition)
+                {
+                    log.Warning($"Unable to precompile open generic type '{GetPrettyName(rootService.ServiceType)}'");
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(rootService.ServiceName))
+                {
+                    CreateDefaultDelegate(rootService.ServiceType, true);                    
+                }
+                else
+                {
+                    CreateNamedDelegate(Tuple.Create(rootService.ServiceType, rootService.ServiceName), true);
+                }
+            }
+
+            string GetPrettyName(Type type)
+            {
+                if (type.GetTypeInfo().IsGenericType)
+                {
+                    return $"{type.FullName.Substring(0, type.FullName.LastIndexOf("`", StringComparison.OrdinalIgnoreCase))}<{string.Join(", ", type.GetTypeInfo().GenericTypeParameters.Select(GetPrettyName))}>";
+                }
+
+                return type.Name;
+            }
+        }
+
+        public void Compile()
+        {
+            Compile(sr => true);
+        }
+
+        public void Compile<TService>(string serviceName = null)
+        {
+            if (string.IsNullOrWhiteSpace(serviceName))
+            {
+                CreateDefaultDelegate(typeof(TService), true);
+            }
+            else
+            {
+                CreateNamedDelegate(Tuple.Create(typeof(TService), serviceName), true);
+            }
         }
 
         private class Storage<T>

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1,7 +1,7 @@
 ﻿/*********************************************************************************
     The MIT License (MIT)
 
-    Copyright (c) 2016 bernhard.richter@gmail.com
+    Copyright (c) 2018 bernhard.richter@gmail.com
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ******************************************************************************
-    LightInject version 5.1.2
+    LightInject version 5.1.3
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>;net46;netstandard1.1;netstandard1.3;netstandard1.6;net452</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.1;netstandard1.3;netstandard1.6;net452</TargetFrameworks>
     <Version>5.1.2</Version>
     <Authors>Bernhard Richter</Authors>   
     <PackageProjectUrl>http//www.lightinject.net</PackageProjectUrl>


### PR DESCRIPTION
This PR adds support for compiling delegates up front.

Initial docs

### Compilation

**LightInject** uses dynamic code compilation either in the form of System.Reflection.Emit or compiled expression trees. When a service is requested from the container, the code needed for creating the service instance is generated and compiled and a delegate for that code is stored for lookup later on so that we only compile it once. These delegates are stored in an AVL tree that ensures maximal performance when looking up a delegate for a given service type. If fact, looking up these delegates is what sets the top performing containers apart. Most high performance container emits approximately the same code, but the approach to storing these delegates may differ. 

**LightInject** provides lock-free service lookup meaning that no locks are involved for getting a service instance after its initial generation and compilation. The only time **LightInject** actually creates a lock is when generating the code for a given service.  That does however mean a potential lock contention problem when many concurrent requests asks for services for the first time.

**LightInject** deals with this potential problem by providing an API for compilation typically used when an application starts.

The following example shows how to compile all registered services.

```c#
container.Compile();
```

One thing to be aware of is that not all services are backed by its own delegate. 

Consider the following service:

```c#
public class Foo
{
	public Foo(Bar bar)
    {
    	Bar = bar;
    }
} 
```

Registered and resolved like this:

```c#
container.Register<Foo>();
container.Register<Bar>();
var foo = container.GetInstance<Foo>();
```

In this case we only create a delegate for resolving `Foo` since that is the only service that is directly requested from the container. The code for creating the `Bar` instance is embedded inside the code for creating the `Foo` instance and hence there is only one delegate created.

We call `Foo` a root service since it is directly requested from the container.	

In fact lets just have a look at the IL generated for creating the `Foo` instance. 

```assembly
newobj Void .ctor() // Bar
newobj Void .ctor(LightInject.SampleLibrary.IBar) //Foo
```

What happens here is that a new instance of `Bar` is created and pushed onto the stack and then we create the `Foo` instance. This is the code that the delegate for `Foo` points to. 

The reason for such a relatively detailed explanation is to illustrate that we don't always create a delegate for a given service and by simply doing a `container.Compile()` we might create a lot of delegates that is never actually executed.  Probably no big deal as long as we don't have tens of thousands of services, but just something to be aware of.

**LightInject** does not attempt to identify root services as that would be very difficult for various reasons.

We can instead use a predicate when compiling services up front.

```C#
container.Compile(sr => sr.ServiceType == typeof(Foo));
```

#### Open Generics

**LightInject** cannot compile open generic services since the actual generic arguments are not known at "compile" time. 

We can however specify the generic arguments like this:

```c#
container.Compile<Foo<int>>()
```

**LightInject** will create a log entry every time a new delegate is created so that information can be used to identify root services that could be compiled up front. In addition to this, a log entry (warning) is also created when trying to compile an open generic service up front.

