### PR TITLE
Support named dependency convention when using custom ServiceSelector

### DIFF
--- a/src/LightInject.Tests/ConstructorInjectionTests.cs
+++ b/src/LightInject.Tests/ConstructorInjectionTests.cs
@@ -393,9 +393,57 @@ namespace LightInject.Tests
             container.Register<IBar, Bar>("Bar");
             container.Register<IBar, AnotherBar>("AnotherBar");
             container.Register<IFoo, FooWithDependency>();
-            var instance = (FooWithDependency)container.GetInstance<IFoo>();
-            Assert.IsAssignableFrom<Bar>(instance.Bar);
+            var firstInstance = (FooWithDependency)container.GetInstance<IFoo>();
+            Assert.IsAssignableFrom<Bar>(firstInstance.Bar);
+
+            container = CreateContainer();
+            container.Register<IBar>(f => new Bar(), "Bar");
+            container.Register<IBar>(f => new AnotherBar(), "AnotherBar");
+            container.Register<IFoo, FooWithAnotherDependency>();
+            var secondInstance = (FooWithAnotherDependency)container.GetInstance<IFoo>();
+            Assert.IsAssignableFrom<AnotherBar>(secondInstance.Bar);
         }
+
+        [Fact]
+        public void GetInstance_AmbiguousIntService_UsesParameterNameAsServiceName()
+        {
+            var options = new ContainerOptions
+            {
+                DefaultServiceSelector = serviceNames => serviceNames.SingleOrDefault(string.IsNullOrWhiteSpace) ?? serviceNames.Last()
+            };
+
+            var container = CreateContainer(options);
+
+            container.Register(f => 84, "second");
+            container.Register(f => 42, "first");
+            container.Register<FooWithIntDependency>();
+            
+            var foo = container.GetInstance<FooWithIntDependency>();
+
+            Assert.Equal(42, foo.First);
+            Assert.Equal(84, foo.Second);
+        }
+
+        [Fact]
+        public void GetInstance_AmbiguousOpenGenericService_UsesParameterNameAsServiceName()
+        {
+            var options = new ContainerOptions
+            {
+                DefaultServiceSelector = serviceNames => serviceNames.SingleOrDefault(string.IsNullOrWhiteSpace) ?? serviceNames.Last()
+            };
+
+            var container = CreateContainer(options);
+
+            container.Register(typeof(IFoo<>),typeof(FooWithOpenGenericDependency<>));
+            container.Register(typeof(IBar<>), typeof(Bar<>), "bar");
+            container.Register(typeof(IBar<>), typeof(Bar<>), "dependency");
+
+            var instance = container.GetInstance<IFoo<int>>();
+
+        }
+
+
+
 
         [Fact]
         public void GetInstance_OpenGenericPerScopeService_ReturnsSameInstance()
@@ -424,6 +472,19 @@ namespace LightInject.Tests
         private IBar CreateBar()
         {
             return new Bar();
-        }       
+        }
+
+
+        public class FooWithIntDependency
+        {
+            public int First { get; }
+            public int Second { get; }
+
+            public FooWithIntDependency(int first, int second)
+            {
+                First = first;
+                Second = second;
+            }
+        }
     }
 }

--- a/src/LightInject.Tests/SampleServices/Foo.cs
+++ b/src/LightInject.Tests/SampleServices/Foo.cs
@@ -150,6 +150,16 @@ namespace LightInject.SampleLibrary
         public IBar Bar { get; private set; }
     }
 
+    public class FooWithAnotherDependency : IFoo
+    {
+        public FooWithAnotherDependency(IBar anotherBar)
+        {
+            Bar = anotherBar;
+        }
+
+        public IBar Bar { get; private set; }
+    }
+
     public class AnotherFooWithDependency : IFoo
     {
         public AnotherFooWithDependency(IBar bar)

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -3678,7 +3678,18 @@ namespace LightInject
                 return skeleton => EmitDependencyUsingFactoryExpression(skeleton, dependency);
             }
 
-            Action<IEmitter> emitter = GetEmitMethod(dependency.ServiceType, dependency.ServiceName);
+            Action<IEmitter> emitter = null;
+            var registrations = GetEmitMethods(dependency.ServiceType);
+            if (registrations.Count > 1)
+            {
+                if (registrations.TryGetValue(dependency.Name, out emitter))
+                {
+                    return emitter;
+                }
+            }
+
+
+            emitter = GetEmitMethod(dependency.ServiceType, dependency.ServiceName);
             if (emitter == null)
             {
                 emitter = GetEmitMethod(dependency.ServiceType, dependency.Name);


### PR DESCRIPTION
Try to resolve dependencies by using parameter names when several mathcing services are registered. When using a custom `DefaultServiceSelector`, this behaviour is broken.