### PR TITLE
Add convenience register extension methods

### DIFF
--- a/src/LightInject.Tests/LazyTests.cs
+++ b/src/LightInject.Tests/LazyTests.cs
@@ -1,0 +1,82 @@
+using System;
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests
+{
+    public class LazyTests : TestBase
+    {
+        [Fact]
+        public void GetInstance_LazyService_ReturnsInstance()
+        {            
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+
+            var lazyInstance = container.GetInstance<Lazy<IFoo>>();
+
+            Assert.IsAssignableFrom<Lazy<IFoo>>(lazyInstance);
+        }
+
+        [Fact]
+        public void GetInstance_LazyService_DoesNotCreateTarget()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, LazyFoo>();
+            LazyFoo.Instances = 0;
+            container.GetInstance<Lazy<IFoo>>();
+            Assert.Equal(0, LazyFoo.Instances);
+        }
+
+        [Fact]
+        public void GetInstance_LazyService_CreatesTargetWhenValuePropertyIsAccessed()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+            
+            var instance = container.GetInstance<Lazy<IFoo>>();
+
+            Assert.IsAssignableFrom<Foo>(instance.Value);
+        }
+
+         [Fact]
+        public void CanGetInstance_LazyForKnownService_ReturnsTrue()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+            Assert.True(container.CanGetInstance(typeof(Lazy<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void CanGetInstance_LazyForUnknownService_ReturnsFalse()
+        {
+            var container = CreateContainer();            
+            Assert.False(container.CanGetInstance(typeof(Lazy<IFoo>), string.Empty));
+        }
+
+        [Fact]
+        public void GetInstance_NamedService_ReturnsLazyThatResolvesNamedService()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo,Foo>();
+            container.Register<IFoo,AnotherFoo>("AnotherFoo");
+
+            var anotherLazyFoo = container.GetInstance<Lazy<IFoo>>("AnotherFoo");
+
+            Assert.IsType<AnotherFoo>(anotherLazyFoo.Value);
+        }
+
+        [Fact]
+        public void GetInstance_LazySingleton_GetsDisposedWhenContainerIsDisposed()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo,DisposableFoo>(new PerContainerLifetime());
+
+            var lazyInstance = container.GetInstance<Lazy<IFoo>>();
+            var instance = (DisposableFoo)lazyInstance.Value;
+            container.Dispose();
+
+            Assert.True(instance.IsDisposed);
+
+        }
+    }
+}

--- a/src/LightInject.Tests/ServiceRegistryExtensionTests.cs
+++ b/src/LightInject.Tests/ServiceRegistryExtensionTests.cs
@@ -1,0 +1,204 @@
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests
+{
+    public class ServiceRegistryExtensionTests : TestBase
+    {
+        private const string ServiceName = "SomeFoo";
+        
+        [Fact]
+        public void ShouldRegisterSingletonService()
+        {
+            var container = CreateContainer();
+
+            container.RegisterSingleton<IFoo, Foo>();
+            
+            AssertSingletonRegistration(container);
+        }
+
+        [Fact]
+         public void ShouldRegisterNamedSingletonService()
+        {
+            var container = CreateContainer();
+
+            container.RegisterSingleton<IFoo, Foo>(ServiceName);
+            
+            AssertSingletonRegistration(container, ServiceName);
+        }
+
+        [Fact]
+        public void ShouldRegisterSingletonServiceUsingTypes()
+        {
+            var container = CreateContainer();
+
+            container.RegisterSingleton(typeof(IFoo), typeof(Foo));
+            AssertSingletonRegistration(container);
+        }
+
+        public void ShouldRegisterNamedSingletonServiceUsingTypes()
+        {
+            var container = CreateContainer();
+
+            container.RegisterSingleton(typeof(IFoo), typeof(Foo), ServiceName);
+            AssertSingletonRegistration(container, ServiceName);
+        }
+
+        [Fact]
+        public void ShouldRegisterSingletonServiceUsingFactory()
+        {
+            var container = CreateContainer();
+
+            container.RegisterSingleton<IFoo>(f => new Foo());
+            
+            AssertSingletonRegistration(container);
+        }
+
+        [Fact]
+         public void ShouldRegisterNamedSingletonServiceUsingFactory()
+        {
+            var container = CreateContainer();
+
+            container.RegisterSingleton<IFoo>(f => new Foo(), ServiceName);
+            
+            AssertSingletonRegistration(container, ServiceName);
+        }
+
+
+        [Fact]
+        public void ShouldRegisterScopedService()
+        {
+            var container = CreateContainer();
+
+            container.RegisterScoped<IFoo, Foo>();
+            
+            AssertScopedRegistration(container);
+        }
+
+        [Fact]
+         public void ShouldRegisterNamedScopedService()
+        {
+            var container = CreateContainer();
+
+            container.RegisterScoped<IFoo, Foo>(ServiceName);
+            
+            AssertScopedRegistration(container, ServiceName);
+        }
+
+        [Fact]
+        public void ShouldRegisterScopedServiceUsingTypes()
+        {
+            var container = CreateContainer();
+
+            container.RegisterScoped(typeof(IFoo), typeof(Foo));
+            AssertScopedRegistration(container);
+        }
+
+        public void ShouldRegisterNamedScopedServiceUsingTypes()
+        {
+            var container = CreateContainer();
+
+            container.RegisterScoped(typeof(IFoo), typeof(Foo), ServiceName);
+            AssertScopedRegistration(container, ServiceName);
+        }
+
+        [Fact]
+        public void ShouldRegisterScopedServiceUsingFactory()
+        {
+            var container = CreateContainer();
+
+            container.RegisterScoped<IFoo>(f => new Foo());
+            
+            AssertScopedRegistration(container);
+        }
+
+        [Fact]
+         public void ShouldRegisterNamedScopedServiceUsingFactory()
+        {
+            var container = CreateContainer();
+
+            container.RegisterScoped<IFoo>(f => new Foo(), ServiceName);
+            
+            AssertScopedRegistration(container, ServiceName);
+        }
+
+         [Fact]
+        public void ShouldRegisterTransientService()
+        {
+            var container = CreateContainer();
+
+            container.RegisterTransient<IFoo, Foo>();
+            
+            AssertTransientRegistration(container);
+        }
+
+         [Fact]
+         public void ShouldRegisterNamedTransientService()
+        {
+            var container = CreateContainer();
+
+            container.RegisterTransient<IFoo, Foo>(ServiceName);
+            
+            AssertTransientRegistration(container, ServiceName);
+        }
+
+        [Fact]
+        public void ShouldRegisterTransientServiceUsingTypes()
+        {
+            var container = CreateContainer();
+
+            container.RegisterTransient(typeof(IFoo), typeof(Foo));
+            AssertTransientRegistration(container);
+        }
+
+        public void ShouldRegisterNamedTransientServiceUsingTypes()
+        {
+            var container = CreateContainer();
+
+            container.RegisterTransient(typeof(IFoo), typeof(Foo), ServiceName);
+            AssertTransientRegistration(container, ServiceName);
+        }
+
+        [Fact]
+        public void ShouldRegisterTransientServiceUsingFactory()
+        {
+            var container = CreateContainer();
+
+            container.RegisterTransient<IFoo>(f => new Foo());
+            
+            AssertTransientRegistration(container);
+        }
+
+        [Fact]
+         public void ShouldRegisterNamedTransientServiceUsingFactory()
+        {
+            var container = CreateContainer();
+
+            container.RegisterTransient<IFoo>(f => new Foo(), ServiceName);
+            
+            AssertTransientRegistration(container, ServiceName);
+        }
+
+        private void AssertTransientRegistration(IServiceRegistry serviceRegistry, string serviceName = null)
+        {
+            serviceName = serviceName ?? string.Empty;
+            Assert.Contains<ServiceRegistration>(serviceRegistry.AvailableServices, sr => sr.ServiceType == typeof(IFoo) && sr.Lifetime == null && sr.ServiceName == serviceName);
+        }
+
+        private void AssertScopedRegistration(IServiceRegistry serviceRegistry, string serviceName = null)
+        {
+            AssertLifetimeRegistration<PerScopeLifetime>(serviceRegistry, serviceName);
+        }
+
+         private void AssertSingletonRegistration(IServiceRegistry serviceRegistry, string serviceName = null)
+        {
+            AssertLifetimeRegistration<PerContainerLifetime>(serviceRegistry, serviceName);
+        }
+
+        private void AssertLifetimeRegistration<TLifetime>(IServiceRegistry serviceRegistry, string serviceName = null)
+        {
+            serviceName = serviceName ?? string.Empty;
+            Assert.Contains<ServiceRegistration>(serviceRegistry.AvailableServices, sr => sr.ServiceType == typeof(IFoo) && sr.Lifetime.GetType() == typeof(TLifetime) && sr.ServiceName == serviceName);
+        }
+   }
+}

--- a/src/LightInject.Tests/omnisharp.json
+++ b/src/LightInject.Tests/omnisharp.json
@@ -1,0 +1,7 @@
+{
+    "fileOptions": {
+      "excludeSearchPatterns": [
+        "Coverage/**/*"
+      ]
+    }
+  }

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1147,6 +1147,198 @@ namespace LightInject
         }
     }
 
+    public static class ServiceRegistryExtensions 
+    {
+         /// <summary>
+        /// Registers a singleton service of type <typeparamref name="TService"> with an implementing type of <typeparamref name="TImplementation">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <typeparam name="TImplementation">The type implementing the service type.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterSingleton<TService, TImplementation>(this IServiceRegistry serviceRegistry) where TImplementation : TService 
+            => serviceRegistry.Register<TService, TImplementation>(new PerContainerLifetime());
+
+        /// <summary>
+        /// Registers a singleton service of type <typeparamref name="TService"> with an implementing type of <typeparamref name="TImplementation">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceName">The name of the service to register.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <typeparam name="TImplementation">The type implementing the service type.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterSingleton<TService, TImplementation>(this IServiceRegistry serviceRegistry, string serviceName) where TImplementation : TService 
+            => serviceRegistry.Register<TService, TImplementation>(serviceName, new PerContainerLifetime());
+
+        /// <summary>
+        /// Registers a singleton service of type <paramref name="serviceType"> with an implementing type of <paramref name="implementingType">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceType">The type of service to register.</param>
+        /// <param name="implementingType">The type implementing the service type.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterSingleton(this IServiceRegistry serviceRegistry, Type serviceType, Type implementingType) 
+            => serviceRegistry.Register(serviceType, implementingType, new PerContainerLifetime());
+
+        /// <summary>
+        /// Registers a singleton service of type <paramref name="serviceType"> with an implementing type of <paramref name="implementingType">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceType">The type of service to register.</param>
+        /// <param name="implementingType">The type implementing the service type.</param>
+        //// <param name="serviceName">The name of the service to register.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterSingleton(this IServiceRegistry serviceRegistry, Type serviceType, Type implementingType, string serviceName) 
+            => serviceRegistry.Register(serviceType, implementingType, serviceName, new PerContainerLifetime());
+
+        /// <summary>
+        /// Registers a singleton service of type <typeparamref name="TService"> using a factory function.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="factory">The factory function used to create the service instance.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterSingleton<TService>(this IServiceRegistry serviceRegistry, Func<IServiceFactory, TService> factory) 
+            => serviceRegistry.Register<TService>(factory, new PerContainerLifetime());
+
+        /// <summary>
+        /// Registers a singleton service of type <typeparamref name="TService"> using a factory function.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="factory">The factory function used to create the service instance.</param>
+        /// <param name="serviceName">The name of the service to register.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterSingleton<TService>(this IServiceRegistry serviceRegistry, Func<IServiceFactory, TService> factory, string serviceName) 
+            => serviceRegistry.Register<TService>(factory, serviceName, new PerContainerLifetime());
+        
+        /// <summary>
+        /// Registers a scoped service of type <typeparamref name="TService"> with an implementing type of <typeparamref name="TImplementation">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <typeparam name="TImplementation">The type implementing the service type.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterScoped<TService, TImplementation>(this IServiceRegistry serviceRegistry) where TImplementation : TService 
+            => serviceRegistry.Register<TService, TImplementation>(new PerScopeLifetime());
+
+        /// <summary>
+        /// Registers a Singleton service of type <typeparamref name="TService"> with an implementing type of <typeparamref name="TImplementation">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceName">The name of the service to register.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <typeparam name="TImplementation">The type implementing the service type.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterScoped<TService, TImplementation>(this IServiceRegistry serviceRegistry, string serviceName) where TImplementation : TService 
+            => serviceRegistry.Register<TService, TImplementation>(serviceName, new PerScopeLifetime());
+
+        /// <summary>
+        /// Registers a scoped service of type <paramref name="serviceType"> with an implementing type of <paramref name="implementingType">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceType">The type of service to register.</param>
+        /// <param name="implementingType">The type implementing the service type.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterScoped(this IServiceRegistry serviceRegistry, Type serviceType, Type implementingType) 
+            => serviceRegistry.Register(serviceType, implementingType, new PerScopeLifetime());
+
+        /// <summary>
+        /// Registers a scoped service of type <paramref name="serviceType"> with an implementing type of <paramref name="implementingType">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceType">The type of service to register.</param>
+        /// <param name="implementingType">The type implementing the service type.</param>
+        //// <param name="serviceName">The name of the service to register.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterScoped(this IServiceRegistry serviceRegistry, Type serviceType, Type implementingType, string serviceName) 
+            => serviceRegistry.Register(serviceType, implementingType, serviceName, new PerScopeLifetime());
+
+        /// <summary>
+        /// Registers a scoped service of type <typeparamref name="TService"> using a factory function.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="factory">The factory function used to create the service instance.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterScoped<TService>(this IServiceRegistry serviceRegistry, Func<IServiceFactory, TService> factory) 
+            => serviceRegistry.Register<TService>(factory, new PerScopeLifetime());
+
+        /// <summary>
+        /// Registers a scoped service of type <typeparamref name="TService"> using a factory function.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="factory">The factory function used to create the service instance.</param>
+        /// <param name="serviceName">The name of the service to register.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterScoped<TService>(this IServiceRegistry serviceRegistry, Func<IServiceFactory, TService> factory, string serviceName) 
+            => serviceRegistry.Register<TService>(factory, serviceName, new PerScopeLifetime());
+        
+        /// <summary>
+        /// Registers a transient service of type <typeparamref name="TService"> with an implementing type of <typeparamref name="TImplementation">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <typeparam name="TImplementation">The type implementing the service type.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterTransient<TService, TImplementation>(this IServiceRegistry serviceRegistry) where TImplementation : TService 
+            => serviceRegistry.Register<TService, TImplementation>();
+
+        /// <summary>
+        /// Registers a transient service of type <typeparamref name="TService"> with an implementing type of <typeparamref name="TImplementation">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceName">The name of the service to register.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <typeparam name="TImplementation">The type implementing the service type.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterTransient<TService, TImplementation>(this IServiceRegistry serviceRegistry, string serviceName) where TImplementation : TService 
+            => serviceRegistry.Register<TService, TImplementation>(serviceName);
+
+        /// <summary>
+        /// Registers a transient service of type <paramref name="serviceType"> with an implementing type of <paramref name="implementingType">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceType">The type of service to register.</param>
+        /// <param name="implementingType">The type implementing the service type.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterTransient(this IServiceRegistry serviceRegistry, Type serviceType, Type implementingType) 
+            => serviceRegistry.Register(serviceType, implementingType);
+
+        /// <summary>
+        /// Registers a transient service of type <paramref name="serviceType"> with an implementing type of <paramref name="implementingType">.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="serviceType">The type of service to register.</param>
+        /// <param name="implementingType">The type implementing the service type.</param>
+        //// <param name="serviceName">The name of the service to register.</param>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterTransient(this IServiceRegistry serviceRegistry, Type serviceType, Type implementingType, string serviceName) 
+            => serviceRegistry.Register(serviceType, implementingType, serviceName);
+
+        /// <summary>
+        /// Registers a transient service of type <typeparamref name="TService"> using a factory function.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="factory">The factory function used to create the service instance.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterTransient<TService>(this IServiceRegistry serviceRegistry, Func<IServiceFactory, TService> factory) 
+            => serviceRegistry.Register<TService>(factory);
+
+        /// <summary>
+        /// Registers a transient service of type <typeparamref name="TService"> using a factory function.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry">.</param>
+        /// <param name="factory">The factory function used to create the service instance.</param>
+        /// <param name="serviceName">The name of the service to register.</param>
+        /// <typeparam name="TService">The type of service to register.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry RegisterTransient<TService>(this IServiceRegistry serviceRegistry, Func<IServiceFactory, TService> factory, string serviceName) 
+            => serviceRegistry.Register<TService>(factory, serviceName);
+    }
+
     /// <summary>
     /// Extends the <see cref="IServiceFactory"/> interface.
     /// </summary>


### PR DESCRIPTION
Adds support for `RegisterTransient`, `RegisterScoped` and `RegisterSingleton` .

This means that we can do 

```
container.RegisterScoped<IFoo, Foo>();
```

instead of 

```
container.Register<IFoo, Foo>(new PerScopeLifetime());
```
