### PR TITLE
Default to PerLogicalCallContextScopeManagerProvider

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ build_script:
 
     dotnet script build.csx
 
+branches:
+  only:
+    - master
+
 artifacts:
 - path: build\Artifacts\NuGet\*.nupkg
   name: NuGet Packages

--- a/src/LightInject.Tests/AsyncTests.cs
+++ b/src/LightInject.Tests/AsyncTests.cs
@@ -17,6 +17,7 @@ namespace LightInject.Tests
         public void GetInstance_Continuation_ThrowException()
         {
             var container = new ServiceContainer();
+            container.ScopeManagerProvider = new PerThreadScopeManagerProvider();
             container.Register<IBar, Bar>(new PerScopeLifetime());
             container.Register<IAsyncFoo, AsyncFoo>();
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2221,7 +2221,11 @@ namespace LightInject
             ConstructorSelector = new MostResolvableConstructorSelector(CanGetInstance);
             constructionInfoProvider = new Lazy<IConstructionInfoProvider>(CreateConstructionInfoProvider);
             methodSkeletonFactory = (returnType, parameterTypes) => new DynamicMethodSkeleton(returnType, parameterTypes);
+#if NET452 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET46 || NETCOREAPP2_0
+            ScopeManagerProvider = new PerLogicalCallContextScopeManagerProvider();
+#else
             ScopeManagerProvider = new PerThreadScopeManagerProvider();
+#endif
 #if NET452 || NET46 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP2_0
             AssemblyLoader = new AssemblyLoader();
 #endif


### PR DESCRIPTION
On target frameworks where it’s available, default to using `PerLogicalCallContextScopeManagerProvider` instead of `PerThreadScopeManagerProvider`.

See also #153.