### PR TITLE
Feature/enable current scope

### DIFF
--- a/src/LightInject.Benchmarks/BeginScopeBenchmarks.cs
+++ b/src/LightInject.Benchmarks/BeginScopeBenchmarks.cs
@@ -1,0 +1,37 @@
+using BenchmarkDotNet.Attributes;
+
+namespace LightInject.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BeginScopeBenchmarks
+    {
+        private IServiceContainer containerWithCurrentScopeEnabled;
+
+        private IServiceContainer containerWithCurrentScopeDisabled;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            containerWithCurrentScopeEnabled = new ServiceContainer(new ContainerOptions() { EnableCurrentScope = true });
+            containerWithCurrentScopeDisabled = new ServiceContainer(new ContainerOptions() { EnableCurrentScope = false });
+        }
+
+        [Benchmark]
+        public void WithCurrentScopeEnabled()
+        {
+            using (var scope = containerWithCurrentScopeEnabled.BeginScope())
+            {
+
+            }
+        }
+
+        [Benchmark]
+        public void WithCurrentScopeDisabled()
+        {
+            using (var scope = containerWithCurrentScopeDisabled.BeginScope())
+            {
+
+            }
+        }
+    }
+}

--- a/src/LightInject.Tests/ScopeGetInstanceTests.cs
+++ b/src/LightInject.Tests/ScopeGetInstanceTests.cs
@@ -381,6 +381,16 @@
                 }
             }
         }
+
+        [Fact]
+        public void ShouldNotUpdateCurrentScopeWhenCurrentScopeIsDisabled()
+        {
+            var container = CreateContainer(new ContainerOptions() { EnableCurrentScope = false });
+            using (container.BeginScope())
+            {
+                Assert.Null(container.ScopeManagerProvider.GetScopeManager(container).CurrentScope);
+            }
+        }
     }
 
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -21,7 +21,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ******************************************************************************
-    LightInject version 6.0.1
+    LightInject version 6.1.0
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -21,7 +21,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ******************************************************************************
-    LightInject version 6.0.0
+    LightInject version 6.0.1
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/
@@ -2549,7 +2549,7 @@ namespace LightInject
             {
                 return new Scope(this);
             }
-            
+
         }
 
         /// <inheritdoc/>

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2239,6 +2239,7 @@ namespace LightInject
             EnableVariance = true;
             EnablePropertyInjection = true;
             LogFactory = t => message => { };
+            EnableCurrentScope = true;
         }
 
         /// <summary>
@@ -2281,6 +2282,16 @@ namespace LightInject
         /// The default value is true.
         /// </remarks>
         public bool EnablePropertyInjection { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a current scope is maintained when starting and ending scopes.
+        /// If services are requested directly from the scope, there we can turn this feature off to improve
+        /// the performance when starting and ending scopes.
+        /// </summary>
+        /// <remarks>
+        /// The default value is true for backward compatibility.
+        /// </remarks>
+        public bool EnableCurrentScope { get; set; }
 
         private static ContainerOptions CreateDefaultContainerOptions() => new ContainerOptions();
     }
@@ -2528,7 +2539,18 @@ namespace LightInject
         }
 
         /// <inheritdoc/>
-        public Scope BeginScope() => ScopeManagerProvider.GetScopeManager(this).BeginScope();
+        public Scope BeginScope()
+        {
+            if (options.EnableCurrentScope)
+            {
+                return ScopeManagerProvider.GetScopeManager(this).BeginScope();
+            }
+            else
+            {
+                return new Scope(this);
+            }
+            
+        }
 
         /// <inheritdoc/>
         public object InjectProperties(object instance)
@@ -6088,6 +6110,15 @@ namespace LightInject
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Scope"/> class.
+        /// </summary>
+        /// <param name="serviceFactory">The <see cref="IServiceFactory"/> that created this <see cref="Scope"/>.</param>
+        public Scope(IServiceFactory serviceFactory)
+        {
+            this.serviceFactory = serviceFactory;
+        }
+
+        /// <summary>
         /// Raised when the <see cref="Scope"/> is completed.
         /// </summary>
         public event EventHandler<EventArgs> Completed;
@@ -6158,7 +6189,7 @@ namespace LightInject
 
         private void OnCompleted()
         {
-            scopeManager.EndScope(this);
+            scopeManager?.EndScope(this);
             var completedHandler = Completed;
             completedHandler?.Invoke(this, new EventArgs());
         }

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- <TargetFrameworks>net46;netstandard1.1;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0;net452</TargetFrameworks> -->
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -26,10 +26,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+    <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    </PackageReference> -->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452'">

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- <TargetFrameworks>net46;netstandard1.1;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0;net452</TargetFrameworks> -->
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
-    <Version>6.0.1</Version>
+    <Version>6.1.0</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR allows the container NOT to maintain the current scope. For instance in AspNet.Core, services are always requested directly from the scope and maintaining a current scopes is just unnecessary overhead.  