### PR TITLE
Added LifeSpanAttribute

### DIFF
--- a/src/LightInject.Tests/LifeSpanTests.cs
+++ b/src/LightInject.Tests/LifeSpanTests.cs
@@ -1,0 +1,34 @@
+#if NETCOREAPP2_0
+
+using System;
+using System.Linq;
+using Xunit;
+
+
+namespace LightInject.Tests
+{
+    public class LifeSpanTests
+    {
+        [Fact]
+        public void ShouldGetLifeSpans()
+        {
+            Assert.Equal(10, GetLifeSpan(typeof(PerRequestLifeTime)));
+        }
+
+
+        private int GetLifeSpan(Type lifetimeType)
+        {
+            var attribute = (LifeSpanAttribute)lifetimeType.GetCustomAttributes(typeof(LifeSpanAttribute), true).FirstOrDefault();
+
+            if (attribute == null)
+            {
+                throw new InvalidOperationException($"The lifetime {lifetimeType} is not decorated with the LifeSpanAttribute");
+            }
+
+            return attribute.Value;
+        }
+
+    }
+}
+
+#endif

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -5973,6 +5973,7 @@ namespace LightInject
     /// <summary>
     /// Ensures that only one instance of a given service can exist within the current <see cref="IServiceContainer"/>.
     /// </summary>
+    [LifeSpan(30)]
     public class PerContainerLifetime : ILifetime, IDisposable, ICloneableLifeTime
     {
         private readonly object syncRoot = new object();
@@ -6018,6 +6019,7 @@ namespace LightInject
     /// <summary>
     /// Ensures that a new instance is created for each request in addition to tracking disposable instances.
     /// </summary>
+    [LifeSpan(10)]
     public class PerRequestLifeTime : ILifetime, ICloneableLifeTime
     {
         /// <inheritdoc/>
@@ -6043,6 +6045,7 @@ namespace LightInject
     /// If the service instance implements <see cref="IDisposable"/>,
     /// it will be disposed when the <see cref="Scope"/> ends.
     /// </remarks>
+    [LifeSpan(20)]
     public class PerScopeLifetime : ILifetime, ICloneableLifeTime
     {
         private readonly ThreadSafeDictionary<Scope, object> instances = new ThreadSafeDictionary<Scope, object>();
@@ -6325,6 +6328,27 @@ namespace LightInject
                 return obj.GetHashCode();
             }
         }
+    }
+
+    /// <summary>
+    /// Use to indicate the lifespan of a given <see cref="ILifetime"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class LifeSpanAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LifeSpanAttribute"/> class.
+        /// </summary>
+        /// <param name="value">A value that indicates the lifespan of a given <see cref="ILifetime"/>.</param>
+        public LifeSpanAttribute(int value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets a value that indicates the lifespan of a given <see cref="ILifetime"/>.
+        /// </summary>
+        public int Value { get; }
     }
 
     /// <summary>

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- <TargetFrameworks>net46;netstandard1.1;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0;net452</TargetFrameworks> -->
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
-    <Version>6.1.0</Version>
+    <Version>6.2.0</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR adds the `LifeSpanAttribute` that makes it possible to indicate the lifespan of a given lifetime. We will use this information later on for validation purposes such as captive dependencies