### PR TITLE
Fixed missing semicolon in IEnumerable Example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -102,7 +102,7 @@ public class AnotherFoo : IFoo {}
 ```c#
 container.Register<IFoo, Foo>();
 container.Register<IFoo, AnotherFoo>("AnotherFoo");
-var instances = container.GetInstance<IEnumerable<IFoo>>()
+var instances = container.GetInstance<IEnumerable<IFoo>>();
 Assert.AreEqual(2, instances.Count());
 ```
 


### PR DESCRIPTION
Just a quick little thing, noticed a missing `;` in the IEnumerable example.