### PR TITLE
Optional Arguments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -696,7 +696,7 @@ Assert.AreEqual(42, foo.Value);
 Assert.IsNotNull(foo.Bar);
 ```
 
-#### Default/Optional parameters
+#### Optional arguments
 
 LightInject will allow for default values to be used when a constructor dependency cannot be resolved.
 
@@ -715,6 +715,7 @@ public class Foo
 We can still resolve `Foo` even though we have not registered a `string` service. 
 
 ```c#
+var container = new ServiceContainer(options => options.EnableOptionalArguments = true);
 container.Register<Foo>();
 var instance = container.GetInstance<Foo>();
 Assert.AreEqual("42", instance.Value)

--- a/readme.md
+++ b/readme.md
@@ -696,6 +696,34 @@ Assert.AreEqual(42, foo.Value);
 Assert.IsNotNull(foo.Bar);
 ```
 
+#### Default/Optional parameters
+
+LightInject will allow for default values to be used when a constructor dependency cannot be resolved.
+
+```c#
+public class Foo
+{
+	public Foo(string value = "42")
+  {
+    Value = value;
+  }
+  
+  public string Value { get; }
+}
+```
+
+We can still resolve `Foo` even though we have not registered a `string` service. 
+
+```c#
+container.Register<Foo>();
+var instance = container.GetInstance<Foo>();
+Assert.AreEqual("42", instance.Value)
+```
+
+> Note that the use cases for optional dependencies should be rare and are to be used with caution.
+
+
+
 ### Property Injection ###
 
 ```c#

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -9,6 +9,8 @@
     "Ldelem",
     "Ldlen",
     "Ldloc",
+    "Ldloca",
+    "Ldnull",
     "Ldstr",
     "MSIL",
     "Stloc",

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -13,5 +13,6 @@
     "MSIL",
     "Stloc",
     "Xunit"
-  ]
+  ],
+  "dotnet-test-explorer.testArguments": "-c release -f netcoreapp2.0"
 }

--- a/src/LightInject.Tests/DefaultValueTests.cs
+++ b/src/LightInject.Tests/DefaultValueTests.cs
@@ -95,6 +95,7 @@ namespace LightInject.Tests
             Assert.Equal(ushort.MinValue, RegisterAndGet<FooWithUShortAsMin>().Value);
         }
 
+        [Fact]
         public void ShouldHandleIntWithDefault()
         {
             Assert.Equal((int)0, RegisterAndGet<FooWithIntAsDefault>().Value);
@@ -212,7 +213,7 @@ namespace LightInject.Tests
         [Fact]
         public void ShouldUseConstructorWithTheMostResolvableParameters()
         {
-            var container = CreateContainer();
+            var container = CreateContainer(new ContainerOptions() { EnableOptionalArguments = true });
             container.Register<ServiceA>();
             container.Register<ServiceB>();
             container.Register<FooWithMultipleConstructors>();
@@ -225,7 +226,7 @@ namespace LightInject.Tests
 
         private T RegisterAndGet<T>()
         {
-            var container = CreateContainer();
+            var container = CreateContainer(new ContainerOptions() { EnableOptionalArguments = true });
             container.Register<T>();
             return container.GetInstance<T>();
         }

--- a/src/LightInject.Tests/DefaultValueTests.cs
+++ b/src/LightInject.Tests/DefaultValueTests.cs
@@ -191,6 +191,24 @@ namespace LightInject.Tests
             Assert.Equal("SomeValue", RegisterAndGet<FooWithStringSet>().Value);
         }
 
+        [Fact]
+        public void ShouldHandleDefaultReferenceType()
+        {
+            Assert.Null(RegisterAndGet<FooWithCustomReferenceTypeSetToNull>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleValueTypeSetToDefault()
+        {
+            Assert.Equal(0, RegisterAndGet<FooWithCustomValueTypeSetToDefault>().Value.Value);
+        }
+
+        [Fact]
+        public void ShouldHandleValueTypeSetToNewInstance()
+        {
+            Assert.Equal(0, RegisterAndGet<FooWithCustomValueTypeSetToNewInstance>().Value.Value);
+        }
+
         private T RegisterAndGet<T>()
         {
             var container = CreateContainer();
@@ -543,6 +561,58 @@ namespace LightInject.Tests
         }
 
         public string Value { get; }
+    }
+
+    public class FooWithCustomReferenceTypeSetToNull
+    {
+        public FooWithCustomReferenceTypeSetToNull(CustomReferenceType value = null)
+        {
+            Value = value;
+        }
+
+        public CustomReferenceType Value { get; }
+    }
+
+    public class FooWithCustomValueTypeSetToDefault
+    {
+        public FooWithCustomValueTypeSetToDefault(CustomValueType value = default(CustomValueType))
+        {
+            Value = value;
+        }
+
+        public CustomValueType Value { get; }
+    }
+
+
+    public class FooWithCustomValueTypeSetToNewInstance
+    {
+        public FooWithCustomValueTypeSetToNewInstance(CustomValueType value = new CustomValueType())
+        {
+            Value = value;
+        }
+
+        public CustomValueType Value { get; }
+    }
+
+    public class CustomReferenceType
+    {
+
+    }
+
+    public class FooWithCustomValueType
+    {
+
+    }
+
+
+    public struct CustomValueType
+    {
+        public int Value;
+
+        public CustomValueType(int value)
+        {
+            Value = value;
+        }
     }
 
     public enum IntEnum

--- a/src/LightInject.Tests/DefaultValueTests.cs
+++ b/src/LightInject.Tests/DefaultValueTests.cs
@@ -209,6 +209,20 @@ namespace LightInject.Tests
             Assert.Equal(0, RegisterAndGet<FooWithCustomValueTypeSetToNewInstance>().Value.Value);
         }
 
+        [Fact]
+        public void ShouldUseConstructorWithTheMostResolvableParameters()
+        {
+            var container = CreateContainer();
+            container.Register<ServiceA>();
+            container.Register<ServiceB>();
+            container.Register<FooWithMultipleConstructors>();
+
+            var instance = container.GetInstance<FooWithMultipleConstructors>();
+
+            Assert.True(instance.ConstructorCalled);
+        }
+
+
         private T RegisterAndGet<T>()
         {
             var container = CreateContainer();
@@ -217,24 +231,38 @@ namespace LightInject.Tests
         }
 
 
-        // [Fact]
-        // public void ShouldHandleClassWithDefaultValue()
-        // {
-        //     var container = CreateContainer();
-        //     container.Register<FooWithPrimitiveTypes>();
+        public class FooWithMultipleConstructors
+        {
+            public bool ConstructorCalled;
 
-        //     var instance = container.GetInstance<FooWithPrimitiveTypes>();
-        // }
+            public FooWithMultipleConstructors(ServiceA service, ServiceB serviceB)
+            {
+            }
 
-        // [Fact]
-        // public void ShouldHandleClassWithDefaultValue2()
-        // {
-        //     var container = CreateContainer();
-        //     container.Register<FooWithGenericDefaultValue<int>>();
+            public FooWithMultipleConstructors(ServiceA service, ServiceB serviceB, ServiceC serviceC = null)
+            {
+                ConstructorCalled = true;
+            }
+        }
 
-        //     var instance = container.GetInstance<FooWithGenericDefaultValue<int>>();
-        // }
+        public class ServiceA
+        {
+
+        }
+
+        public class ServiceB
+        {
+
+        }
+
+        public class ServiceC
+        {
+
+        }
     }
+
+
+
 
     public class FooWithGenericDefaultValue<T>
     {

--- a/src/LightInject.Tests/DefaultValueTests.cs
+++ b/src/LightInject.Tests/DefaultValueTests.cs
@@ -148,12 +148,53 @@ namespace LightInject.Tests
             Assert.Equal(long.MinValue, RegisterAndGet<FooWithLongAsMin>().Value);
         }
 
+        [Fact]
+        public void ShouldHandleULongWithDefault()
+        {
+            Assert.Equal((ulong)0, RegisterAndGet<FooWithULongAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleULongWithMaxValue()
+        {
+            Assert.Equal(ulong.MaxValue, RegisterAndGet<FooWithULongAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleULongWithMinValue()
+        {
+            Assert.Equal(ulong.MinValue, RegisterAndGet<FooWithULongAsMin>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleIntEnumWithDefault()
+        {
+            Assert.Equal(IntEnum.None, RegisterAndGet<FooWithIntEnumAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleIntEnumWithValueSet()
+        {
+            Assert.Equal(IntEnum.SomeValue, RegisterAndGet<FooWithIntEnumSet>().Value);
+        }
+
+
+        [Fact]
+        public void ShouldHandleStringWithDefault()
+        {
+            Assert.Equal((string)null, RegisterAndGet<FooWithStringAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleStringWithValueSet()
+        {
+            Assert.Equal("SomeValue", RegisterAndGet<FooWithStringSet>().Value);
+        }
 
         private T RegisterAndGet<T>()
         {
             var container = CreateContainer();
             container.Register<T>();
-
             return container.GetInstance<T>();
         }
 
@@ -181,7 +222,6 @@ namespace LightInject.Tests
     {
         public FooWithGenericDefaultValue(T value = default)
         {
-
         }
     }
 
@@ -433,7 +473,83 @@ namespace LightInject.Tests
         public long Value { get; }
     }
 
+    public class FooWithULongAsDefault
+    {
+        public FooWithULongAsDefault(ulong value = default)
+        {
+            Value = value;
+        }
 
+        public ulong Value { get; }
+    }
+
+
+    public class FooWithULongAsMax
+    {
+        public FooWithULongAsMax(ulong value = ulong.MaxValue)
+        {
+            Value = value;
+        }
+
+        public ulong Value { get; }
+    }
+
+    public class FooWithULongAsMin
+    {
+        public FooWithULongAsMin(ulong value = ulong.MinValue)
+        {
+            Value = value;
+        }
+
+        public ulong Value { get; }
+    }
+
+    public class FooWithIntEnumAsDefault
+    {
+        public FooWithIntEnumAsDefault(IntEnum value = default)
+        {
+            Value = value;
+        }
+
+        public IntEnum Value { get; }
+    }
+
+
+    public class FooWithIntEnumSet
+    {
+        public FooWithIntEnumSet(IntEnum value = IntEnum.SomeValue)
+        {
+            Value = value;
+        }
+
+        public IntEnum Value { get; }
+    }
+
+    public class FooWithStringAsDefault
+    {
+        public FooWithStringAsDefault(string value = default)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+    }
+
+    public class FooWithStringSet
+    {
+        public FooWithStringSet(string value = "SomeValue")
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+    }
+
+    public enum IntEnum
+    {
+        None,
+        SomeValue
+    }
 
 
     /// <summary>

--- a/src/LightInject.Tests/DefaultValueTests.cs
+++ b/src/LightInject.Tests/DefaultValueTests.cs
@@ -1,0 +1,481 @@
+using System;
+using Xunit;
+
+namespace LightInject.Tests
+{
+    public class DefaultValueTests : TestBase
+    {
+        [Fact]
+        public void ShouldHandleBoolWithDefault()
+        {
+            Assert.False(RegisterAndGet<FooWithBoolAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleBoolWithTrueValue()
+        {
+            Assert.True(RegisterAndGet<FooWithBoolAsTrue>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleBoolWithFalseValue()
+        {
+            Assert.False(RegisterAndGet<FooWithBoolAsFalse>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleByteWithDefault()
+        {
+            Assert.Equal((byte)0, RegisterAndGet<FooWithByteAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleByteWithMaxValue()
+        {
+            Assert.Equal(byte.MaxValue, RegisterAndGet<FooWithByteAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleByteWithMinValue()
+        {
+            Assert.Equal(byte.MinValue, RegisterAndGet<FooWithByteAsMin>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleSByteWithDefault()
+        {
+            Assert.Equal((sbyte)0, RegisterAndGet<FooWithSByteAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleSByteWithMaxValue()
+        {
+            Assert.Equal(sbyte.MaxValue, RegisterAndGet<FooWithSByteAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleSByteWithMinValue()
+        {
+            Assert.Equal(sbyte.MinValue, RegisterAndGet<FooWithSByteAsMin>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleShortWithDefault()
+        {
+            Assert.Equal((short)0, RegisterAndGet<FooWithShortAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleShortWithMaxValue()
+        {
+            Assert.Equal(short.MaxValue, RegisterAndGet<FooWithShortAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleShortWithMinValue()
+        {
+            Assert.Equal(short.MinValue, RegisterAndGet<FooWithShortAsMin>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleUShortWithDefault()
+        {
+            Assert.Equal((ushort)0, RegisterAndGet<FooWithUShortAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleUShortWithMaxValue()
+        {
+            Assert.Equal(ushort.MaxValue, RegisterAndGet<FooWithUShortAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleUShortWithMinValue()
+        {
+            Assert.Equal(ushort.MinValue, RegisterAndGet<FooWithUShortAsMin>().Value);
+        }
+
+        public void ShouldHandleIntWithDefault()
+        {
+            Assert.Equal((int)0, RegisterAndGet<FooWithIntAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleIntWithMaxValue()
+        {
+            Assert.Equal(int.MaxValue, RegisterAndGet<FooWithIntAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleIntWithMinValue()
+        {
+            Assert.Equal(int.MinValue, RegisterAndGet<FooWithIntAsMin>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleUIntWithDefault()
+        {
+            Assert.Equal((uint)0, RegisterAndGet<FooWithUIntAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleUIntWithMaxValue()
+        {
+            Assert.Equal(uint.MaxValue, RegisterAndGet<FooWithUIntAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleUIntWithMinValue()
+        {
+            Assert.Equal(uint.MinValue, RegisterAndGet<FooWithUIntAsMin>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleLongWithDefault()
+        {
+            Assert.Equal((long)0, RegisterAndGet<FooWithLongAsDefault>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleLongWithMaxValue()
+        {
+            Assert.Equal(long.MaxValue, RegisterAndGet<FooWithLongAsMax>().Value);
+        }
+
+        [Fact]
+        public void ShouldHandleLongWithMinValue()
+        {
+            Assert.Equal(long.MinValue, RegisterAndGet<FooWithLongAsMin>().Value);
+        }
+
+
+        private T RegisterAndGet<T>()
+        {
+            var container = CreateContainer();
+            container.Register<T>();
+
+            return container.GetInstance<T>();
+        }
+
+
+        // [Fact]
+        // public void ShouldHandleClassWithDefaultValue()
+        // {
+        //     var container = CreateContainer();
+        //     container.Register<FooWithPrimitiveTypes>();
+
+        //     var instance = container.GetInstance<FooWithPrimitiveTypes>();
+        // }
+
+        // [Fact]
+        // public void ShouldHandleClassWithDefaultValue2()
+        // {
+        //     var container = CreateContainer();
+        //     container.Register<FooWithGenericDefaultValue<int>>();
+
+        //     var instance = container.GetInstance<FooWithGenericDefaultValue<int>>();
+        // }
+    }
+
+    public class FooWithGenericDefaultValue<T>
+    {
+        public FooWithGenericDefaultValue(T value = default)
+        {
+
+        }
+    }
+
+    public class FooWithBoolAsDefault
+    {
+        public FooWithBoolAsDefault(bool value = default)
+        {
+            Value = value;
+        }
+
+        public bool Value { get; }
+    }
+
+    public class FooWithBoolAsTrue
+    {
+        public FooWithBoolAsTrue(bool value = true)
+        {
+            Value = value;
+        }
+
+        public bool Value { get; }
+    }
+
+    public class FooWithBoolAsFalse
+    {
+        public FooWithBoolAsFalse(bool value = false)
+        {
+            Value = value;
+        }
+
+        public bool Value { get; }
+    }
+
+    public class FooWithByteAsDefault
+    {
+        public FooWithByteAsDefault(byte value = default)
+        {
+            Value = value;
+        }
+
+        public byte Value { get; }
+    }
+
+    public class FooWithByteAsMax
+    {
+        public FooWithByteAsMax(byte value = byte.MaxValue)
+        {
+            Value = value;
+        }
+
+        public byte Value { get; }
+    }
+
+    public class FooWithByteAsMin
+    {
+        public FooWithByteAsMin(byte value = byte.MinValue)
+        {
+            Value = value;
+        }
+
+        public byte Value { get; }
+    }
+
+
+    public class FooWithSByteAsDefault
+    {
+        public FooWithSByteAsDefault(sbyte value = default)
+        {
+            Value = value;
+        }
+
+        public sbyte Value { get; }
+    }
+
+
+    public class FooWithSByteAsMax
+    {
+        public FooWithSByteAsMax(sbyte value = sbyte.MaxValue)
+        {
+            Value = value;
+        }
+
+        public sbyte Value { get; }
+    }
+
+    public class FooWithSByteAsMin
+    {
+        public FooWithSByteAsMin(sbyte value = sbyte.MinValue)
+        {
+            Value = value;
+        }
+
+        public sbyte Value { get; }
+    }
+
+    public class FooWithShortAsDefault
+    {
+        public FooWithShortAsDefault(short value = default)
+        {
+            Value = value;
+        }
+
+        public short Value { get; }
+    }
+
+
+    public class FooWithShortAsMax
+    {
+        public FooWithShortAsMax(short value = short.MaxValue)
+        {
+            Value = value;
+        }
+
+        public short Value { get; }
+    }
+
+    public class FooWithShortAsMin
+    {
+        public FooWithShortAsMin(short value = short.MinValue)
+        {
+            Value = value;
+        }
+
+        public short Value { get; }
+    }
+
+    public class FooWithUShortAsDefault
+    {
+        public FooWithUShortAsDefault(ushort value = default)
+        {
+            Value = value;
+        }
+
+        public ushort Value { get; }
+    }
+
+
+    public class FooWithUShortAsMax
+    {
+        public FooWithUShortAsMax(ushort value = ushort.MaxValue)
+        {
+            Value = value;
+        }
+
+        public ushort Value { get; }
+    }
+
+    public class FooWithUShortAsMin
+    {
+        public FooWithUShortAsMin(ushort value = ushort.MinValue)
+        {
+            Value = value;
+        }
+
+        public ushort Value { get; }
+    }
+
+    public class FooWithIntAsDefault
+    {
+        public FooWithIntAsDefault(int value = default)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+
+
+    public class FooWithIntAsMax
+    {
+        public FooWithIntAsMax(int value = int.MaxValue)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+
+    public class FooWithIntAsMin
+    {
+        public FooWithIntAsMin(int value = int.MinValue)
+        {
+            Value = value;
+        }
+
+        public int Value { get; }
+    }
+
+
+    public class FooWithUIntAsDefault
+    {
+        public FooWithUIntAsDefault(uint value = default)
+        {
+            Value = value;
+        }
+
+        public uint Value { get; }
+    }
+
+
+    public class FooWithUIntAsMax
+    {
+        public FooWithUIntAsMax(uint value = uint.MaxValue)
+        {
+            Value = value;
+        }
+
+        public uint Value { get; }
+    }
+
+    public class FooWithUIntAsMin
+    {
+        public FooWithUIntAsMin(uint value = uint.MinValue)
+        {
+            Value = value;
+        }
+
+        public uint Value { get; }
+    }
+
+    public class FooWithLongAsDefault
+    {
+        public FooWithLongAsDefault(long value = default)
+        {
+            Value = value;
+        }
+
+        public long Value { get; }
+    }
+
+
+    public class FooWithLongAsMax
+    {
+        public FooWithLongAsMax(long value = long.MaxValue)
+        {
+            Value = value;
+        }
+
+        public long Value { get; }
+    }
+
+    public class FooWithLongAsMin
+    {
+        public FooWithLongAsMin(long value = long.MinValue)
+        {
+            Value = value;
+        }
+
+        public long Value { get; }
+    }
+
+
+
+
+    /// <summary>
+    /// Boolean, Byte, SByte, Int16, UInt16, Int32, UInt32, Int64, UInt64, IntPtr, UIntPtr, Char, Double, and Single.
+    /// </summary>
+    public class FooWithPrimitiveTypes
+    {
+        public FooWithPrimitiveTypes(bool boolValue = default,
+                                     byte byteValue = default,
+                                     sbyte sbyteValue = default,
+                                     short shortValue = default,
+                                     ushort ushortValue = default,
+                                     int intvalue = default,
+                                     uint uintValue = default,
+                                     long longValue = default,
+                                     ulong ulongValue = default,
+                                     IntPtr intPtrValue = default,
+                                     UIntPtr uIntPtrValue = default)
+        {
+            BoolValue = boolValue;
+            ByteValue = byteValue;
+            SbyteValue = sbyteValue;
+            ShortValue = shortValue;
+            UshortValue = ushortValue;
+            Intvalue = intvalue;
+            UintValue = uintValue;
+            LongValue = longValue;
+            UlongValue = ulongValue;
+            IntPtrValue = intPtrValue;
+            UIntPtrValue = uIntPtrValue;
+        }
+
+        public bool BoolValue { get; }
+        public byte ByteValue { get; }
+        public sbyte SbyteValue { get; }
+        public short ShortValue { get; }
+        public ushort UshortValue { get; }
+        public int Intvalue { get; }
+        public uint UintValue { get; }
+        public long LongValue { get; }
+        public ulong UlongValue { get; }
+        public IntPtr IntPtrValue { get; }
+        public UIntPtr UIntPtrValue { get; }
+    }
+}

--- a/src/LightInject.Tests/DefaultValueVerificationTests.cs
+++ b/src/LightInject.Tests/DefaultValueVerificationTests.cs
@@ -1,0 +1,17 @@
+#if NET40 || NET452 || NETSTANDARD11 || NETSTANDARD13 || NET46
+using Xunit;
+
+namespace LightInject.Tests
+{
+
+    [Trait("Category", "Verification")]
+    [Collection("Verification")]
+    public class DefaultValuesVerificationTests : DefaultValueTests
+    {
+        internal override IServiceContainer CreateContainer()
+        {
+            return VerificationContainerFactory.CreateContainerForAssemblyVerification();
+        }
+    }
+}
+#endif

--- a/src/LightInject.Tests/EmitterTests.cs
+++ b/src/LightInject.Tests/EmitterTests.cs
@@ -657,6 +657,14 @@ namespace LightInject.Tests
         }
 
         [Fact]
+        public void Emit_InvalidOpCodeForLong_ThrowsException()
+        {
+            var emitter = new Emitter(null, new Type[] { });
+
+            Assert.Throws<NotSupportedException>(() => emitter.Emit(OpCodes.Call, (long)42));
+        }
+
+        [Fact]
         public void ToString_Instruction_ReturnsCodeAsString()
         {
             var instruction = new Instruction(OpCodes.Stloc, null);

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net452</TargetFrameworks>
+    <!-- <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net452</TargetFrameworks> -->
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net46;net452</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0579</NoWarn>
   </PropertyGroup>
 

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net452</TargetFrameworks> -->
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net46;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net46;net452</TargetFrameworks>
+    <!-- <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net46;net452</TargetFrameworks> -->
     <NoWarn>$(NoWarn);CS0579</NoWarn>
   </PropertyGroup>
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2038,7 +2038,6 @@ namespace LightInject
                 return;
             }
 
-            // bool is represented as an int32 so there is no need to cast or unbox
             if (type == typeof(bool) && emitter.StackType == typeof(int))
             {
                 return;

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1032,9 +1032,13 @@ namespace LightInject
 
 #if NETSTANDARD1_1 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0
 
+        /// <summary>
+        /// Pushes the argument as a constant expression.
+        /// </summary>
+        /// <param name="arg">The argument value to be pushed.</param>
+        /// <param name="type">The type of the argument to be pushed.</param>
         void PushConstantValue(object arg, Type type);
 #endif
-
 
         /// <summary>
         /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
@@ -2074,7 +2078,6 @@ namespace LightInject
             {
                 return;
             }
-
 
             if (!type.GetTypeInfo().IsAssignableFrom(emitter.StackType.GetTypeInfo()))
             {
@@ -4016,7 +4019,6 @@ namespace LightInject
                     {
                         throw new InvalidOperationException(string.Format(UnresolvedDependencyError, dependency));
                     }
-
                 }
             }
 
@@ -4025,9 +4027,6 @@ namespace LightInject
 
         private Action<IEmitter> GetEmitMethodForDefaultValue(ConstructorDependency constructorDependency)
         {
-            Type[] typesUsingInt32AsDefaultValue = new Type[] { typeof(bool), typeof(byte), typeof(sbyte), typeof(short), typeof(ushort), typeof(int), typeof(uint) };
-            Type[] typesThatNeedsConversionToInt64 = new Type[] { typeof(long), typeof(ulong) };
-
             Type parameterType = constructorDependency.Parameter.ParameterType;
 #if NETSTANDARD1_1 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0
             return (emitter) =>
@@ -4037,6 +4036,7 @@ namespace LightInject
                 {
                     defaultValue = TypeHelper.GetDefaultValue(parameterType);
                 }
+
                 emitter.PushConstantValue(defaultValue, parameterType);
             };
 
@@ -4060,37 +4060,31 @@ namespace LightInject
                     var defaultValue = parameter.DefaultValue != null ? (byte)parameter.DefaultValue : 0;
                     emitter.Emit(OpCodes.Ldc_I4, defaultValue);
                 }
-
                 else if (parameterType == typeof(sbyte))
                 {
                     var defaultValue = parameter.DefaultValue != null ? (sbyte)parameter.DefaultValue : 0;
                     emitter.Emit(OpCodes.Ldc_I4, defaultValue);
                 }
-
                 else if (parameterType == typeof(short))
                 {
                     var defaultValue = parameter.DefaultValue != null ? (short)parameter.DefaultValue : 0;
                     emitter.Emit(OpCodes.Ldc_I4, defaultValue);
                 }
-
                 else if (parameterType == typeof(ushort))
                 {
                     var defaultValue = parameter.DefaultValue != null ? (ushort)parameter.DefaultValue : 0;
                     emitter.Emit(OpCodes.Ldc_I4, defaultValue);
                 }
-
                 else if (parameterType == typeof(uint))
                 {
                     uint unsignedDefaultValue = parameter.DefaultValue != null ? (uint)parameter.DefaultValue : 0;
                     emitter.Emit(OpCodes.Ldc_I4, (int)unsignedDefaultValue);
                 }
-
                 else if (parameterType == typeof(int))
                 {
                     var defaultValue = parameter.DefaultValue != null ? (int)parameter.DefaultValue : 0;
                     emitter.Emit(OpCodes.Ldc_I4, defaultValue);
                 }
-
                 else if (parameterType == typeof(long))
                 {
                     var defaultValue = parameter.DefaultValue != null ? (long)parameter.DefaultValue : 0;
@@ -4111,14 +4105,11 @@ namespace LightInject
                     {
                         emitter.Emit(OpCodes.Ldstr, (string)parameter.DefaultValue);
                     }
-                    // var defaultValue = parameter.DefaultValue != null ? (string)parameter.DefaultValue : null;
-                    // emitter.Emit(OpCodes.Ldstr, defaultValue);
                 }
                 else if (parameterType.GetTypeInfo().IsClass)
                 {
                     emitter.Emit(OpCodes.Ldnull);
                 }
-
                 else if (parameterType.GetTypeInfo().IsValueType)
                 {
                     var local = emitter.DeclareLocal(parameterType);
@@ -4128,9 +4119,6 @@ namespace LightInject
                 }
             };
         }
-
-
-
 
         private void EmitDependencyUsingFactoryExpression(IEmitter emitter, Dependency dependency)
         {
@@ -5419,46 +5407,14 @@ namespace LightInject
         }
 
         /// <summary>
-        /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
+        /// Pushes the argument value as a constant expression.
         /// </summary>
-        /// <param name="code">The MSIL instruction to be put onto the stream.</param>
-        /// <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
-        public void PushULong(OpCode code, ulong arg)
-        {
-            if (code == OpCodes.Ldc_I8)
-            {
-                stack.Push(Expression.Constant(arg, typeof(ulong)));
-            }
-            else
-            {
-                throw new NotSupportedException(code.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
-        /// </summary>
-        /// <param name="code">The MSIL instruction to be put onto the stream.</param>
-        /// <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
-        public void PushUInt(uint arg)
-        {
-            stack.Push(Expression.Constant(arg, typeof(uint)));
-        }
-
-        /// <summary>
-        /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
-        /// </summary>
-        /// <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
-        public void PushBool(bool arg)
-        {
-            stack.Push(Expression.Constant(arg, typeof(bool)));
-        }
-
+        /// <param name="arg">The argument value to be pushed.</param>
+        /// <param name="type">The type of the argument value to be pushed.</param>
         public void PushConstantValue(object arg, Type type)
         {
             stack.Push(Expression.Constant(arg, type));
         }
-
 
         /// <summary>
         /// Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.
@@ -5717,7 +5673,7 @@ namespace LightInject
 
         private bool CanCreateParameterDependency(ParameterInfo parameterInfo)
         {
-            return canGetInstance(parameterInfo.ParameterType, string.Empty) || canGetInstance(parameterInfo.ParameterType, GetServiceName(parameterInfo));
+            return canGetInstance(parameterInfo.ParameterType, string.Empty) || canGetInstance(parameterInfo.ParameterType, GetServiceName(parameterInfo)) || parameterInfo.HasDefaultValue;
         }
     }
 
@@ -8181,41 +8137,15 @@ namespace LightInject
         }
 
 #if NETSTANDARD1_1 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0
-          public void PushConstantValue(object arg, Type type)
-          {
-              stack.Push(type);
-              instructions.Add(new Instruction<object>(OpCodes.Nop, arg, il => il.PushConstantValue(arg, type)));
-          }
+        /// <inheritdoc/>
+        public void PushConstantValue(object arg, Type type)
+        {
+            stack.Push(type);
+            instructions.Add(new Instruction<object>(OpCodes.Nop, arg, il => il.PushConstantValue(arg, type)));
+        }
 
 #endif
     }
-
-    // #if NET452 || NET46 || NETCOREAPP2_0
-    //     internal static class ILGeneratorExtensions
-    //     {
-
-    //         internal static void PushULong(this ILGenerator generator, OpCode code, ulong arg)
-    //         {
-    //             long value = (long)arg;
-    //             generator.Emit(OpCodes.Ldc_I8, value);
-    //         }
-
-    //         internal static void PushUInt(this ILGenerator generator, uint arg)
-    //         {
-    //             int value = (int)arg;
-    //             generator.Emit(OpCodes.Ldc_I4_0, value);
-    //         }
-
-    //         internal static void PushBool(this ILGenerator generator, bool arg)
-    //         {
-    //             var value = arg ? 1 : 0;
-    //             generator.Emit(OpCodes.Ldc_I4, value);
-    //         }
-    //     }
-
-
-    // #endif
-
 
 #if NET452
 
@@ -8569,6 +8499,7 @@ but either way the scope has to be started with 'container.BeginScope()'";
                 return null;
             }
         }
+
 #if NETSTANDARD1_1 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0
         public static object GetDefaultValue(Type type)
         {

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
     <!-- <TargetFrameworks>netstandard2.0;netcoreapp2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks> -->
-    <Version>6.2.1</Version>
+    <Version>6.3.0</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- <TargetFrameworks>net46;netstandard1.1;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0;net452</TargetFrameworks> -->
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
+    <!-- <TargetFrameworks>netstandard2.0;netcoreapp2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks> -->
     <Version>6.2.1</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>


### PR DESCRIPTION
This PR adds support for optional arguments if the `ContainerOptions.EnableOptionalArguments` property is set to `true`. The default is `false`.

