### PR TITLE
Allow passing a composition root instance to RegisterFrom

### DIFF
--- a/build/build.csx
+++ b/build/build.csx
@@ -23,8 +23,8 @@ Step test = () =>
 [StepDescription("Creates the NuGet packages")]
 Step pack = () =>
 {
-    // test();
-    // testcoverage();
+    test();
+    testcoverage();
     DotNet.Pack();
     NuGetUtils.CreateSourcePackage(BuildContext.RepositoryFolder, BuildContext.ProjectName, BuildContext.NuGetArtifactsFolder);
 };

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -4,7 +4,7 @@
     "OrganizeImports": true
   },
   "RoslynExtensionsOptions": {
-    "EnableAnalyzersSupport": false,
+    "EnableAnalyzersSupport": true,
     "EnableDecompilationSupport": true
   },
   "script": {

--- a/readme.md
+++ b/readme.md
@@ -901,6 +901,11 @@ Allows explicit execution of a composition root.
 container.RegisterFrom<SampleCompositionRoot>();
 ```
 
+Alternatively we can also pass an existing composition root instance.
+
+```c#
+container.RegisterFrom(new SampleCompositionRoot());
+```
 
 ## Generics ##
 

--- a/src/LightInject.Tests/CompositionRootExecutorMock.cs
+++ b/src/LightInject.Tests/CompositionRootExecutorMock.cs
@@ -7,7 +7,12 @@ namespace LightInject.Tests
     {
         public void Execute(Type compositionRootType)
         {
-            ((IInvocationContext<ICompositionRootExecutor>) this).Invoke(c => c.Execute(compositionRootType));
+            ((IInvocationContext<ICompositionRootExecutor>)this).Invoke(c => c.Execute(compositionRootType));
+        }
+
+        public void Execute<TCompositionRoot>(TCompositionRoot compositionRoot) where TCompositionRoot : ICompositionRoot
+        {
+            ((IInvocationContext<ICompositionRootExecutor>)this).Invoke(c => c.Execute(compositionRoot));
         }
     }
 }

--- a/src/LightInject.Tests/CompositionRootExecutorTests.cs
+++ b/src/LightInject.Tests/CompositionRootExecutorTests.cs
@@ -1,28 +1,50 @@
 namespace LightInject.Tests
-{    
+{
     using LightMock;
-    using Xunit;    
-    
+    using Xunit;
+
     public class CompositionRootExecutorTests
     {
         [Fact]
         public void Execute_CompositionRootType_IsCreatedAndExecuted()
-        {            
+        {
             CompositionRootMock compositionRootMock = new CompositionRootMock();
             var serviceContainerMock = new ContainerMock();
             var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock);
             executor.Execute(typeof(CompositionRootMock));
-            compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);            
+            compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);
         }
 
         [Fact]
         public void Execute_CompositionRootType_IsCreatedAndExecutedOnlyOnce()
-        {            
+        {
             CompositionRootMock compositionRootMock = new CompositionRootMock();
             var serviceContainerMock = new ContainerMock();
             var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock);
             executor.Execute(typeof(CompositionRootMock));
             executor.Execute(typeof(CompositionRootMock));
-            compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);           
+            compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);
         }
-    }}
+
+        [Fact]
+        public void Execute_Composition_IsExecuted()
+        {
+            CompositionRootMock compositionRootMock = new CompositionRootMock();
+            var serviceContainerMock = new ContainerMock();
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock);
+            executor.Execute(compositionRootMock);
+            compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);
+        }
+
+        [Fact]
+        public void Execute_Composition_IsExecutedOnlyOnce()
+        {
+            CompositionRootMock compositionRootMock = new CompositionRootMock();
+            var serviceContainerMock = new ContainerMock();
+            var executor = new CompositionRootExecutor(serviceContainerMock, (t) => compositionRootMock);
+            executor.Execute(compositionRootMock);
+            executor.Execute(compositionRootMock);
+            compositionRootMock.Assert(c => c.Compose(The<IServiceContainer>.IsAnyValue), Invoked.Once);
+        }
+    }
+}

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -208,6 +208,11 @@ namespace LightInject.Tests
             throw new NotImplementedException();
         }
 
+        public IServiceRegistry RegisterFrom<TCompositionRoot>(TCompositionRoot compositionRoot) where TCompositionRoot : ICompositionRoot
+        {
+            throw new NotImplementedException();
+        }
+
         public IServiceRegistry RegisterConstructorDependency<TDependency>(Func<IServiceFactory, ParameterInfo, TDependency> factory)
         {
             throw new NotImplementedException();

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -7,18 +7,16 @@ namespace LightInject.Tests
     using System.Collections.Generic;
     using System.Linq;
     using System.Security;
-
     using System.Text;
     using System.Threading.Tasks;
-
     using LightInject;
     using LightInject.SampleLibrary;
     using Xunit;
     using Xunit.Sdk;
-    using Foo = LightInject.SampleLibrary.Foo;
-    using IFoo = LightInject.SampleLibrary.IFoo;
-    using IBar = LightInject.SampleLibrary.IBar;
     using Bar = LightInject.SampleLibrary.Bar;
+    using Foo = LightInject.SampleLibrary.Foo;
+    using IBar = LightInject.SampleLibrary.IBar;
+    using IFoo = LightInject.SampleLibrary.IFoo;
 
     public class ServiceContainerTests : TestBase
     {
@@ -1691,7 +1689,7 @@ namespace LightInject.Tests
 
 #if NET452 || NET40 || NET46 || NETCOREAPP2_0
         [Fact]
-        public void RegisterFrom_CompositionRoot_CallsCompositionRootExecutor()
+        public void RegisterFrom_CompositionRootType_CallsCompositionRootExecutor()
         {
             var container = (ServiceContainer)CreateContainer();
             var compositionRootExecutorMock = new CompositionRootExecutorMock();
@@ -1700,6 +1698,19 @@ namespace LightInject.Tests
             container.RegisterFrom<CompositionRootMock>();
 
             compositionRootExecutorMock.Assert(c => c.Execute(typeof(CompositionRootMock)), Invoked.Once);
+        }
+
+        [Fact]
+        public void RegisterFrom_CompositionRoot_CallsCompositionRootExecutor()
+        {
+            var container = (ServiceContainer)CreateContainer();
+            var compositionRootExecutorMock = new CompositionRootExecutorMock();
+            container.CompositionRootExecutor = compositionRootExecutorMock;
+            var compositionRootMock = new CompositionRootMock();
+
+            container.RegisterFrom(compositionRootMock);
+
+            compositionRootExecutorMock.Assert(c => c.Execute(compositionRootMock), Invoked.Once);
         }
 #endif
         [Fact]

--- a/src/LightInject.Tests/ServiceRegistryExtensionTests.cs
+++ b/src/LightInject.Tests/ServiceRegistryExtensionTests.cs
@@ -18,7 +18,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedSingletonService()
+        public void ShouldRegisterNamedSingletonService()
         {
             var container = CreateContainer();
 
@@ -57,7 +57,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedSingletonServiceUsingFactory()
+        public void ShouldRegisterNamedSingletonServiceUsingFactory()
         {
             var container = CreateContainer();
 
@@ -66,7 +66,7 @@ namespace LightInject.Tests
             AssertSingletonRegistration<IFoo>(container, ServiceName);
         }
 
-         [Fact]
+        [Fact]
         public void ShouldRegisterSingletonServiceUsingNonGenericFactory()
         {
             var container = CreateContainer();
@@ -117,7 +117,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedScopedService()
+        public void ShouldRegisterNamedScopedService()
         {
             var container = CreateContainer();
 
@@ -155,7 +155,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedScopedServiceUsingFactory()
+        public void ShouldRegisterNamedScopedServiceUsingFactory()
         {
             var container = CreateContainer();
 
@@ -175,7 +175,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedScopedServiceUsingonGenericFactory()
+        public void ShouldRegisterNamedScopedServiceUsingonGenericFactory()
         {
             var container = CreateContainer();
 
@@ -215,8 +215,8 @@ namespace LightInject.Tests
             AssertTransientRegistration<IFoo>(container);
         }
 
-         [Fact]
-         public void ShouldRegisterNamedTransientService()
+        [Fact]
+        public void ShouldRegisterNamedTransientService()
         {
             var container = CreateContainer();
 
@@ -254,7 +254,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedTransientServiceUsingFactory()
+        public void ShouldRegisterNamedTransientServiceUsingFactory()
         {
             var container = CreateContainer();
 
@@ -274,7 +274,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-         public void ShouldRegisterNamedTransientServiceUsingonGenericFactory()
+        public void ShouldRegisterNamedTransientServiceUsingonGenericFactory()
         {
             var container = CreateContainer();
 
@@ -283,7 +283,7 @@ namespace LightInject.Tests
             AssertTransientRegistration<IFoo>(container, ServiceName);
         }
 
-         [Fact]
+        [Fact]
         public void ShouldRegisterConcreteTransientService()
         {
             var container = CreateContainer();
@@ -303,7 +303,6 @@ namespace LightInject.Tests
             AssertTransientRegistration<Foo>(container);
         }
 
-
         private void AssertTransientRegistration<TService>(IServiceRegistry serviceRegistry, string serviceName = null)
         {
             serviceName = serviceName ?? string.Empty;
@@ -315,7 +314,7 @@ namespace LightInject.Tests
             AssertLifetimeRegistration<PerScopeLifetime, TService>(serviceRegistry, serviceName);
         }
 
-         private void AssertSingletonRegistration<TService>(IServiceRegistry serviceRegistry, string serviceName = null)
+        private void AssertSingletonRegistration<TService>(IServiceRegistry serviceRegistry, string serviceName = null)
         {
             AssertLifetimeRegistration<PerContainerLifetime, TService>(serviceRegistry, serviceName);
         }
@@ -325,5 +324,22 @@ namespace LightInject.Tests
             serviceName = serviceName ?? string.Empty;
             Assert.Contains<ServiceRegistration>(serviceRegistry.AvailableServices, sr => sr.ServiceType == typeof(TService) && sr.Lifetime.GetType() == typeof(TLifetime) && sr.ServiceName == serviceName);
         }
-   }
+
+        public class CompositionRootWithArgument : ICompositionRoot
+        {
+            public CompositionRootWithArgument(Configuration configuration)
+            {
+            }
+
+            public void Compose(IServiceRegistry serviceRegistry)
+            {
+                serviceRegistry.Register<Foo>();
+            }
+        }
+
+        public class Configuration
+        {
+
+        }
+    }
 }

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4479,19 +4479,6 @@ namespace LightInject
             }
         }
 
-        private struct ClosedGenericCandidate
-        {
-            public ClosedGenericCandidate(Type closedGenericImplentingType, ILifetime lifetime)
-            {
-                ClosedGenericImplentingType = closedGenericImplentingType;
-                Lifetime = lifetime;
-            }
-
-            public Type ClosedGenericImplentingType { get; }
-
-            public ILifetime Lifetime { get; }
-        }
-
         private Action<IEmitter> CreateEmitMethodForEnumerableServiceServiceRequest(Type serviceType)
         {
             Type actualServiceType = TypeHelper.GetElementType(serviceType);
@@ -4826,6 +4813,19 @@ namespace LightInject
                 Lifetime = lifetime ?? DefaultLifetime,
             };
             Register(serviceRegistration);
+        }
+
+        private struct ClosedGenericCandidate
+        {
+            public ClosedGenericCandidate(Type closedGenericImplentingType, ILifetime lifetime)
+            {
+                ClosedGenericImplentingType = closedGenericImplentingType;
+                Lifetime = lifetime;
+            }
+
+            public Type ClosedGenericImplentingType { get; }
+
+            public ILifetime Lifetime { get; }
         }
 
         private class Storage<T>

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -492,6 +492,15 @@ namespace LightInject
             where TCompositionRoot : ICompositionRoot, new();
 
         /// <summary>
+        /// Registers services from the given <paramref name="compositionRoot"/>.
+        /// </summary>
+        /// <param name="compositionRoot">The <see cref="ICompositionRoot"/> from which to register services.</param>
+        /// <typeparam name="TCompositionRoot">The type of <see cref="ICompositionRoot"/> to register from.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        IServiceRegistry RegisterFrom<TCompositionRoot>(TCompositionRoot compositionRoot)
+            where TCompositionRoot : ICompositionRoot;
+
+        /// <summary>
         /// Registers a factory delegate to be used when resolving a constructor dependency for
         /// an implicitly registered service.
         /// </summary>
@@ -990,7 +999,8 @@ namespace LightInject
     }
 
     /// <summary>
-    /// Represents a class that is responsible for instantiating and executing an <see cref="ICompositionRoot"/>.
+    /// Represents a class that is responsible for executing an <see cref="ICompositionRoot"/> and making
+    /// sure that we don't execute the same composition root twice.
     /// </summary>
     public interface ICompositionRootExecutor
     {
@@ -999,6 +1009,14 @@ namespace LightInject
         /// </summary>
         /// <param name="compositionRootType">The concrete <see cref="ICompositionRoot"/> type to be instantiated and executed.</param>
         void Execute(Type compositionRootType);
+
+        /// <summary>
+        /// Executes the <see cref="ICompositionRoot.Compose"/> method.
+        /// </summary>
+        /// <typeparam name="TCompositionRoot">The type of <see cref="ICompositionRoot"/> to register from.</typeparam>
+        /// <param name="compositionRoot">The <see cref="ICompositionRoot"/> to be executed.</param>
+        void Execute<TCompositionRoot>(TCompositionRoot compositionRoot)
+            where TCompositionRoot : ICompositionRoot;
     }
 
     /// <summary>
@@ -2775,6 +2793,14 @@ namespace LightInject
             where TCompositionRoot : ICompositionRoot, new()
         {
             CompositionRootExecutor.Execute(typeof(TCompositionRoot));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IServiceRegistry RegisterFrom<TCompositionRoot>(TCompositionRoot compositionRoot)
+           where TCompositionRoot : ICompositionRoot
+        {
+            CompositionRootExecutor.Execute(compositionRoot);
             return this;
         }
 
@@ -6851,6 +6877,23 @@ namespace LightInject
                     {
                         executedCompositionRoots.Add(compositionRootType);
                         var compositionRoot = activator(compositionRootType);
+                        compositionRoot.Compose(serviceRegistry);
+                    }
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Execute<TCompositionRoot>(TCompositionRoot compositionRoot)
+            where TCompositionRoot : ICompositionRoot
+        {
+            if (!executedCompositionRoots.Contains(typeof(TCompositionRoot)))
+            {
+                lock (syncRoot)
+                {
+                    if (!executedCompositionRoots.Contains(typeof(TCompositionRoot)))
+                    {
+                        executedCompositionRoots.Add(typeof(TCompositionRoot));
                         compositionRoot.Compose(serviceRegistry);
                     }
                 }


### PR DESCRIPTION
This PR adds support for passing an composition root instance to `RegisterFrom`