### PR TITLE
Bugfix/execute override only once

### DIFF
--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4645,8 +4645,7 @@ namespace LightInject
                 var serviceOverrides = overrides.Items.Where(so => so.CanOverride(serviceRegistration)).ToArray();
                 foreach (var serviceOverride in serviceOverrides)
                 {
-                    serviceOverride.Execute(this, serviceRegistration);
-                    //serviceRegistration = serviceOverride.ServiceRegistrationFactory(this, serviceRegistration);
+                    serviceRegistration = serviceOverride.Execute(this, serviceRegistration);
                 }
 
                 if (serviceRegistration.Lifetime == null)

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2956,11 +2956,7 @@ namespace LightInject
         /// <inheritdoc/>
         public IServiceRegistry Override(Func<ServiceRegistration, bool> serviceSelector, Func<IServiceFactory, ServiceRegistration, ServiceRegistration> serviceRegistrationFactory)
         {
-            var serviceOverride = new ServiceOverride
-            {
-                CanOverride = serviceSelector,
-                ServiceRegistrationFactory = serviceRegistrationFactory,
-            };
+            var serviceOverride = new ServiceOverride(serviceSelector, serviceRegistrationFactory);
             overrides.Add(serviceOverride);
             return this;
         }
@@ -4649,7 +4645,8 @@ namespace LightInject
                 var serviceOverrides = overrides.Items.Where(so => so.CanOverride(serviceRegistration)).ToArray();
                 foreach (var serviceOverride in serviceOverrides)
                 {
-                    serviceRegistration = serviceOverride.ServiceRegistrationFactory(this, serviceRegistration);
+                    serviceOverride.Execute(this, serviceRegistration);
+                    //serviceRegistration = serviceOverride.ServiceRegistrationFactory(this, serviceRegistration);
                 }
 
                 if (serviceRegistration.Lifetime == null)
@@ -5014,9 +5011,45 @@ namespace LightInject
 
         private class ServiceOverride
         {
-            public Func<ServiceRegistration, bool> CanOverride { get; set; }
+            private bool hasExecuted;
 
-            public Func<IServiceFactory, ServiceRegistration, ServiceRegistration> ServiceRegistrationFactory { get; set; }
+            private readonly object lockObject = new object();
+
+            private readonly Func<IServiceFactory, ServiceRegistration, ServiceRegistration> serviceRegistrationFactory;
+
+            public ServiceOverride(Func<ServiceRegistration, bool> canOverride, Func<IServiceFactory, ServiceRegistration, ServiceRegistration> serviceRegistrationFactory)
+            {
+                CanOverride = canOverride;
+                this.serviceRegistrationFactory = serviceRegistrationFactory;
+            }
+
+            public Func<ServiceRegistration, bool> CanOverride { get; }
+
+            [ExcludeFromCodeCoverage]
+            public ServiceRegistration Execute(IServiceFactory serviceFactory, ServiceRegistration serviceRegistration)
+            {
+                // Excluded since the double checked lock is virtually impossible to produce.
+                if (hasExecuted)
+                {
+                    return serviceRegistration;
+                }
+                else
+                {
+                    lock (lockObject)
+                    {
+                        if (hasExecuted)
+                        {
+                            return serviceRegistration;
+                        }
+                        else
+                        {
+                            hasExecuted = true;
+                            var registration = serviceRegistrationFactory(serviceFactory, serviceRegistration);
+                            return registration;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -5010,11 +5010,11 @@ namespace LightInject
 
         private class ServiceOverride
         {
-            private bool hasExecuted;
-
             private readonly object lockObject = new object();
 
             private readonly Func<IServiceFactory, ServiceRegistration, ServiceRegistration> serviceRegistrationFactory;
+
+            private bool hasExecuted;
 
             public ServiceOverride(Func<ServiceRegistration, bool> canOverride, Func<IServiceFactory, ServiceRegistration, ServiceRegistration> serviceRegistrationFactory)
             {

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
     <!-- <TargetFrameworks>netstandard2.0;netcoreapp2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks> -->
-    <Version>6.3.5</Version>
+    <Version>6.3.6</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR ensures that service overrides are executed only once. This is really important since we can choose to alter the lifetime of a registration.