### PR TITLE
Bugfix/initializer

### DIFF
--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1700,6 +1700,23 @@ namespace LightInject.Tests
             container.GetInstance<IFoo>();
         }
 
+        [Fact]
+        public void GetInstance_UsingInitializer_PassesScopeAsServiceFactory()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+            IServiceFactory passedFactory = null;
+            container.Initialize<IFoo>((factory, instance) => { passedFactory = factory; });
+
+            using (var scope = container.BeginScope())
+            {
+                scope.GetInstance<IFoo>();
+                Assert.Same(scope, passedFactory);
+            }
+        }
+
+
+
 
 #if NET452 || NET40 || NET46 || NETCOREAPP2_0
         [Fact]

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1686,6 +1686,20 @@ namespace LightInject.Tests
             Assert.IsAssignableFrom<Bar>(foo.Bar);
         }
 
+        [Fact]
+        public void GetInstance_UsingInitializerWithDecoratedService_PassesDecoratorAsInstance()
+        {
+            var container = CreateContainer();
+            container.Register<IFoo, Foo>();
+            container.Decorate<IFoo, FooDecorator>();
+            container.Initialize<IFoo>((factory, instance) =>
+            {
+                Assert.IsType<FooDecorator>(instance);
+            });
+
+            container.GetInstance<IFoo>();
+        }
+
 
 #if NET452 || NET40 || NET46 || NETCOREAPP2_0
         [Fact]

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4672,8 +4672,13 @@ namespace LightInject
                 Type delegateType = postProcessor.Initialize.GetType();
                 var delegateIndex = constants.Add(postProcessor.Initialize);
                 emitter.PushConstant(delegateIndex, delegateType);
+
                 var serviceFactoryIndex = constants.Add(this);
                 emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));
+                var scopeManagerIndex = CreateScopeManagerIndex();
+                emitter.PushConstant(scopeManagerIndex, typeof(IScopeManager));
+                emitter.PushArgument(1);
+                emitter.Emit(OpCodes.Call, ServiceFactoryLoader.LoadServiceFactoryMethod);
                 emitter.Push(instanceVariable);
                 MethodInfo invokeMethod = delegateType.GetTypeInfo().GetDeclaredMethod("Invoke");
                 emitter.Call(invokeMethod);

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1607,6 +1607,16 @@ namespace LightInject
                 return registration;
             });
         }
+
+        /// <summary>
+        /// Allows post-processing of a service instance.
+        /// </summary>
+        /// <param name="serviceRegistry">The target <see cref="IServiceRegistry"/>.</param>
+        /// <param name="processor">An action delegate that exposes the created service instance.</param>
+        /// <typeparam name="TService">The type of service to initialize.</typeparam>
+        /// <returns>The <see cref="IServiceRegistry"/>, for chaining calls.</returns>
+        public static IServiceRegistry Initialize<TService>(this IServiceRegistry serviceRegistry, Action<IServiceFactory, TService> processor)
+            => serviceRegistry.Initialize(sr => sr.ServiceType == typeof(TService), (factory, instance) => processor(factory, (TService)instance));
     }
 
     /// <summary>
@@ -3865,28 +3875,6 @@ namespace LightInject
                     EmitNewInstanceUsingImplementingType(emitter, constructionInfo, null);
                 }
             }
-
-            var processors = initializers.Items.Where(i => i.Predicate(serviceRegistration)).ToArray();
-            if (processors.Length == 0)
-            {
-                return;
-            }
-
-            LocalBuilder instanceVariable = emitter.DeclareLocal(serviceRegistration.ServiceType);
-            emitter.Store(instanceVariable);
-            foreach (var postProcessor in processors)
-            {
-                Type delegateType = postProcessor.Initialize.GetType();
-                var delegateIndex = constants.Add(postProcessor.Initialize);
-                emitter.PushConstant(delegateIndex, delegateType);
-                var serviceFactoryIndex = constants.Add(this);
-                emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));
-                emitter.Push(instanceVariable);
-                MethodInfo invokeMethod = delegateType.GetTypeInfo().GetDeclaredMethod("Invoke");
-                emitter.Call(invokeMethod);
-            }
-
-            emitter.Push(instanceVariable);
         }
 
         private void EmitDecorators(ServiceRegistration serviceRegistration, IEnumerable<DecoratorRegistration> serviceDecorators, IEmitter emitter, Action<IEmitter> decoratorTargetEmitMethod)
@@ -4670,6 +4658,28 @@ namespace LightInject
             {
                 EmitNewInstance(serviceRegistration, emitter);
             }
+
+            var processors = initializers.Items.Where(i => i.Predicate(serviceRegistration)).ToArray();
+            if (processors.Length == 0)
+            {
+                return;
+            }
+
+            LocalBuilder instanceVariable = emitter.DeclareLocal(serviceRegistration.ServiceType);
+            emitter.Store(instanceVariable);
+            foreach (var postProcessor in processors)
+            {
+                Type delegateType = postProcessor.Initialize.GetType();
+                var delegateIndex = constants.Add(postProcessor.Initialize);
+                emitter.PushConstant(delegateIndex, delegateType);
+                var serviceFactoryIndex = constants.Add(this);
+                emitter.PushConstant(serviceFactoryIndex, typeof(IServiceFactory));
+                emitter.Push(instanceVariable);
+                MethodInfo invokeMethod = delegateType.GetTypeInfo().GetDeclaredMethod("Invoke");
+                emitter.Call(invokeMethod);
+            }
+
+            emitter.Push(instanceVariable);
         }
 
         private void EmitLifetime(ServiceRegistration serviceRegistration, Action<IEmitter> emitMethod, IEmitter emitter)

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks>
     <!-- <TargetFrameworks>netstandard2.0;netcoreapp2.0;netstandard1.6;netstandard1.3;netstandard1.1;net46;net452</TargetFrameworks> -->
-    <Version>6.3.6</Version>
+    <Version>6.4.0</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR fixes a potential bug where we didn't pass the current scope to the `Initialize` method.
Also added a new `Initialize` overload that filters initialization by the `TService` generic argument.