### PR TITLE
Feature/optimize for large object graphs (transients)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   "omnisharp.path": "latest",
   "cSpell.words": [
     "Callvirt",
+    "Castclass",
     "Conv",
     "Initobj",
     "Ldarg",

--- a/omnisharp.json
+++ b/omnisharp.json
@@ -4,7 +4,7 @@
     "OrganizeImports": true
   },
   "RoslynExtensionsOptions": {
-    "EnableAnalyzersSupport": true,
+    "EnableAnalyzersSupport": false,
     "EnableDecompilationSupport": true
   },
   "script": {

--- a/src/LightInject.Tests/ConstructorInjectionOptimizedTests.cs
+++ b/src/LightInject.Tests/ConstructorInjectionOptimizedTests.cs
@@ -1,0 +1,10 @@
+﻿using Xunit;
+namespace LightInject.Tests
+{
+    
+    public class ConstructorInjectionOptimizedTests : ConstructorInjectionTests
+    {
+        internal override IServiceContainer CreateContainer() 
+            => new ServiceContainer((options => options.OptimizeForLargeObjectGraphs = true));
+    }
+}

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -13,7 +13,7 @@
       </PropertyGroup>
     </When>
   </Choose>
-  <PropertyGroup Condition=" '$(TestTargetFramework)'=='net6.0' ">
+  <PropertyGroup Condition=" '$(TestTargetFramework)'=='net6.1' ">
     <DefineConstants>USE_ASSEMBLY_VERIFICATION</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="LightMock" Version="2.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />

--- a/src/LightInject.Tests/ServiceContainerOptimizedTests.cs
+++ b/src/LightInject.Tests/ServiceContainerOptimizedTests.cs
@@ -1,0 +1,13 @@
+﻿
+using Xunit;
+
+namespace LightInject.Tests
+{
+    [Trait("Category", "Verification")]
+    [Collection("Verification")]
+    public class ServiceContainerOptimizedTests : ServiceContainerTests
+    {
+        internal override IServiceContainer CreateContainer() 
+            => new ServiceContainer((options => options.OptimizeForLargeObjectGraphs = true));
+    }
+}

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1043,7 +1043,8 @@ namespace LightInject.Tests
             var container = CreateContainer();
             container.Register(typeof(IFoo), typeof(FooWithRecursiveDependency));
             var exception = Assert.Throws<InvalidOperationException>(() => container.GetAllInstances<IFoo>());
-            Assert.Equal(ErrorMessages.RecursiveDependency, exception.InnerException.InnerException.InnerException.Message);
+            var test = exception.GetBaseException();
+            Assert.Equal(ErrorMessages.RecursiveDependency, exception.GetBaseException().Message);
         }
 
         [Fact]

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -2412,6 +2412,7 @@ namespace LightInject
             LogFactory = t => message => { };
             EnableCurrentScope = true;
             EnableOptionalArguments = false;
+            OptimizeForLargeObjectGraphs = false;
         }
 
         /// <summary>
@@ -2472,6 +2473,15 @@ namespace LightInject
         /// The default value is false.
         /// </remarks>
         public bool EnableOptionalArguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to optimize for very large object graphs.
+        /// This is usually not needed unless there is a lot of transients involved.
+        /// </summary>
+        /// <remarks>
+        /// The default value is false.
+        /// </remarks>
+        public bool OptimizeForLargeObjectGraphs { get; set; }
 
         private static ContainerOptions CreateDefaultContainerOptions() => new ContainerOptions();
     }
@@ -4648,7 +4658,15 @@ namespace LightInject
 
                 if (serviceRegistration.Lifetime == null)
                 {
-                    EmitNewInstanceWithDecorators(serviceRegistration, emitter);
+                    if (options.OptimizeForLargeObjectGraphs)
+                    {
+                        EmitLifetime(serviceRegistration, e => EmitNewInstanceWithDecorators(serviceRegistration, e), emitter);
+                    }
+                    else
+                    {
+                        EmitLifetime(serviceRegistration, e => EmitNewInstanceWithDecorators(serviceRegistration, e), emitter);
+                        //EmitNewInstanceWithDecorators(serviceRegistration, emitter);
+                    }
                 }
                 else
                 {
@@ -4697,8 +4715,33 @@ namespace LightInject
             emitter.Push(instanceVariable);
         }
 
+        private int GetInstanceDelegateIndex(ServiceRegistration serviceRegistration, Action<IEmitter> emitMethod)
+        {
+            if (servicesToDelegatesIndex.ContainsUninitializedValued(serviceRegistration))
+            {
+                throw new InvalidOperationException(
+                        string.Format("Recursive dependency detected: ServiceType:{0}, ServiceName:{1}]", serviceRegistration.ServiceType, serviceRegistration.ServiceName));
+            }
+
+            return servicesToDelegatesIndex.GetOrAdd(serviceRegistration, _ => CreateInstanceDelegateIndex(emitMethod));
+        }
+
+
         private void EmitLifetime(ServiceRegistration serviceRegistration, Action<IEmitter> emitMethod, IEmitter emitter)
         {
+            if (serviceRegistration.Lifetime == null)
+            {
+                int instanceDelegateIndex = GetInstanceDelegateIndex(serviceRegistration, emitMethod);
+                var invokeMethod = typeof(GetInstanceDelegate).GetTypeInfo().GetDeclaredMethod("Invoke");
+                emitter.PushConstant(instanceDelegateIndex, typeof(GetInstanceDelegate));
+                emitter.PushArgument(0);
+                PushScope(emitter);
+                emitter.Emit(OpCodes.Callvirt, invokeMethod);
+                return;
+            }
+
+
+
             if (serviceRegistration.Lifetime is PerScopeLifetime)
             {
                 int instanceDelegateIndex = servicesToDelegatesIndex.GetOrAdd(serviceRegistration, _ => CreateInstanceDelegateIndex(emitMethod));
@@ -4873,6 +4916,7 @@ namespace LightInject
                     catch (InvalidOperationException ex)
                     {
                         dependencyStack.Clear();
+                        servicesToDelegatesIndex.Remove(sr => sr.ServiceType == serviceType);
                         throw new InvalidOperationException(
                             string.Format("Unable to resolve type: {0}, service name: {1}", serviceType, serviceName),
                             ex);
@@ -5206,6 +5250,24 @@ namespace LightInject
         {
             var lazyResult = this.concurrentDictionary.GetOrAdd(key, k => new Lazy<TValue>(() => valueFactory(k), LazyThreadSafetyMode.ExecutionAndPublication));
             return lazyResult.Value;
+        }
+
+        public bool ContainsUninitializedValued(TKey key)
+        {
+            if (concurrentDictionary.TryGetValue(key, out var value))
+            {
+                return !value.IsValueCreated;
+            }
+            return false;
+        }
+
+        public void Remove(Func<TKey, bool> predicate)
+        {
+            var entry = concurrentDictionary.SingleOrDefault(kvp => predicate(kvp.Key)).Key;
+            if (entry != null)
+            {
+                _ = concurrentDictionary.TryRemove(entry, out var lazy);
+            }
         }
     }
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4903,6 +4903,7 @@ namespace LightInject
                 var serviceEmitter = GetEmitMethod(serviceType, serviceName);
                 if (serviceEmitter == null && throwError)
                 {
+                    servicesToDelegatesIndex.Remove(new ServiceRegistration() { ServiceType = serviceType, ServiceName = serviceName });
                     throw new InvalidOperationException(
                         string.Format("Unable to resolve type: {0}, service name: {1}", serviceType, serviceName));
                 }
@@ -4916,7 +4917,7 @@ namespace LightInject
                     catch (InvalidOperationException ex)
                     {
                         dependencyStack.Clear();
-                        servicesToDelegatesIndex.Remove(sr => sr.ServiceType == serviceType);
+                        servicesToDelegatesIndex.Remove(new ServiceRegistration() { ServiceType = serviceType, ServiceName = serviceName });
                         throw new InvalidOperationException(
                             string.Format("Unable to resolve type: {0}, service name: {1}", serviceType, serviceName),
                             ex);
@@ -5261,13 +5262,9 @@ namespace LightInject
             return false;
         }
 
-        public void Remove(Func<TKey, bool> predicate)
+        public void Remove(TKey key)
         {
-            var entry = concurrentDictionary.SingleOrDefault(kvp => predicate(kvp.Key)).Key;
-            if (entry != null)
-            {
-                _ = concurrentDictionary.TryRemove(entry, out var lazy);
-            }
+            concurrentDictionary.TryRemove(key, out var lazy);
         }
     }
 

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4664,8 +4664,7 @@ namespace LightInject
                     }
                     else
                     {
-                        EmitLifetime(serviceRegistration, e => EmitNewInstanceWithDecorators(serviceRegistration, e), emitter);
-                        //EmitNewInstanceWithDecorators(serviceRegistration, emitter);
+                        EmitNewInstanceWithDecorators(serviceRegistration, emitter);
                     }
                 }
                 else
@@ -4717,7 +4716,7 @@ namespace LightInject
 
         private int GetInstanceDelegateIndex(ServiceRegistration serviceRegistration, Action<IEmitter> emitMethod)
         {
-            if (servicesToDelegatesIndex.ContainsUninitializedValued(serviceRegistration))
+            if (servicesToDelegatesIndex.ContainsUninitializedValue(serviceRegistration))
             {
                 throw new InvalidOperationException(
                         string.Format("Recursive dependency detected: ServiceType:{0}, ServiceName:{1}]", serviceRegistration.ServiceType, serviceRegistration.ServiceName));
@@ -5253,7 +5252,12 @@ namespace LightInject
             return lazyResult.Value;
         }
 
-        public bool ContainsUninitializedValued(TKey key)
+        /// <summary>
+        /// Determines if the dictionary contains an uninitialized value with the given <paramref name="key"/>. 
+        /// </summary>
+        /// <param name="key">The key for which to check for an uninitialized value.</param>
+        /// <returns>true if the dictionary contains an uninitialized value at the given <paramref name="key"/>.</returns>
+        public bool ContainsUninitializedValue(TKey key)
         {
             if (concurrentDictionary.TryGetValue(key, out var value))
             {
@@ -5262,6 +5266,10 @@ namespace LightInject
             return false;
         }
 
+        /// <summary>
+        /// Removes an entry with the given <paramref name="key"/> if it exists it the dictionary. 
+        /// </summary>
+        /// <param name="key">The key for which to remove an entry.</param>
         public void Remove(TKey key)
         {
             concurrentDictionary.TryRemove(key, out var lazy);


### PR DESCRIPTION
This PR adds a new option called `OptimizeForLargeObjectGraphs` that favors objects graphs with a  large number of transient services.   