### PR TITLE
Disable nullable explicitly

### DIFF
--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -1,4 +1,5 @@
-﻿#if NETSTANDARD2_0
+﻿#nullable disable
+#if NETSTANDARD2_0
 #define USE_EXPRESSIONS
 #endif
 

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -13,6 +13,7 @@
     <Copyright>Bernhard Richter</Copyright>
     <PackageTags>Ioc Dependency-Injection Inversion-of-Control WinRT Windows-Runtime</PackageTags>
     <Description>An ultra lightweight Inversion of Control container for the .Net framework. See LightInject.Source for the source distribution.</Description>
+    <LangVersion>8.0</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
Hey,

We use LightInject(a source code package) as a built-in container for EasyNetQ.

We started a migration to Nullable Reference Types recently and observed build warnings because LightInject doesn't support them(and this is fine).

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/664889/189486436-d6a3e2f1-8f38-4ed6-99f1-0971d37ad7dc.png">

Could you consider adding `#nullable disable` pragma? It looks like the simplest way how these warnings could be suppressed.

Anyway, thanks for LightInject 🚀