### PR TITLE
Fixed issue #578 by setting serviceName to string.Empty if no registrations for the specified serviceType are found.

### DIFF
--- a/src/LightInject.Tests/LazyTests.cs
+++ b/src/LightInject.Tests/LazyTests.cs
@@ -38,19 +38,21 @@ namespace LightInject.Tests
             Assert.IsAssignableFrom<Foo>(instance.Value);
         }
 
-        [Fact]
-        public void CanGetInstance_LazyForKnownService_ReturnsTrue()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_LazyForKnownService_ReturnsTrue(string serviceName)
         {
             var container = CreateContainer();
             container.Register<IFoo, Foo>();
-            Assert.True(container.CanGetInstance(typeof(Lazy<IFoo>), string.Empty));
+            Assert.True(container.CanGetInstance(typeof(Lazy<IFoo>), serviceName));
         }
 
-        [Fact]
-        public void CanGetInstance_LazyForUnknownService_ReturnsFalse()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_LazyForUnknownService_ReturnsFalse(string serviceName)
         {
             var container = CreateContainer();
-            Assert.False(container.CanGetInstance(typeof(Lazy<IFoo>), string.Empty));
+            Assert.False(container.CanGetInstance(typeof(Lazy<IFoo>), serviceName));
         }
 
         [Fact]

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -1127,59 +1127,67 @@ namespace LightInject.Tests
 
         }
 
-        [Fact]
-        public void CanGetInstance_KnownService_ReturnsTrue()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_KnownService_ReturnsTrue(string serviceName)
         {
             var container = CreateContainer();
             container.Register<IFoo, Foo>();
-            var canCreateInstance = container.CanGetInstance(typeof(IFoo), string.Empty);
+            var canCreateInstance = container.CanGetInstance(typeof(IFoo), serviceName);
             Assert.True(canCreateInstance);
         }
-        [Fact]
-        public void CanGetInstance_UnknownService_ReturnFalse()
+        
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_UnknownService_ReturnFalse(string serviceName)
         {
             var container = CreateContainer();
             container.Register<IFoo, Foo>();
-            var canCreateInstance = container.CanGetInstance(typeof(IBar), string.Empty);
+            var canCreateInstance = container.CanGetInstance(typeof(IBar), serviceName);
             Assert.False(canCreateInstance);
         }
 
-        [Fact]
-        public void CanGetInstance_FuncForKnownService_ReturnsTrue()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_FuncForKnownService_ReturnsTrue(string serviceName)
         {
             var container = CreateContainer();
             container.Register<IFoo, Foo>();
-            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), serviceName));
         }
 
-        [Fact]
-        public void CanGetInstance_FuncForUnknownService_ReturnsFalse()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_FuncForUnknownService_ReturnsFalse(string serviceName)
         {
             var container = CreateContainer();
-            Assert.False(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+            Assert.False(container.CanGetInstance(typeof(Func<IFoo>), serviceName));
         }
 
-        [Fact]
-        public void CanGetInstance_ExplicitlyRegisteredFunc_ReturnsTrue()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_ExplicitlyRegisteredFunc_ReturnsTrue(string serviceName)
         {
             var container = CreateContainer();
             container.Register<Func<IFoo>>(f => (() => new Foo()));
-            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), serviceName));
         }
 
-        [Fact]
-        public void CanGetInstance_ParameterizedFuncForKnownService_ReturnsTrue()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_ParameterizedFuncForKnownService_ReturnsTrue(string serviceName)
         {
             var container = CreateContainer();
             container.Register<int, IFoo>((factory, i) => new FooWithOneParameter(i));
-            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+            Assert.True(container.CanGetInstance(typeof(Func<IFoo>), serviceName));
         }
 
-        [Fact]
-        public void CanGetInstance_ParameterizedFuncForUnknownService_ReturnsFalse()
+        [Theory]
+        [MemberData(nameof(StringDataGenerator.NullOrWhiteSpaceData), MemberType = typeof(StringDataGenerator))]
+        public void CanGetInstance_ParameterizedFuncForUnknownService_ReturnsFalse(string serviceName)
         {
             var container = CreateContainer();
-            Assert.False(container.CanGetInstance(typeof(Func<IFoo>), string.Empty));
+            Assert.False(container.CanGetInstance(typeof(Func<IFoo>), serviceName));
         }
 
         [Fact]

--- a/src/LightInject.Tests/StringDataGenerator.cs
+++ b/src/LightInject.Tests/StringDataGenerator.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace LightInject.Tests;
+
+public static class StringDataGenerator
+{
+    public static IEnumerable<object[]> NullOrWhiteSpaceData()
+    {
+        yield return new object[] { null };
+        yield return new object[] { string.Empty };
+        yield return new object[] { " " };
+        yield return new object[] { "\t" };
+        yield return new object[] { "\n" };
+        yield return new object[] { "\r" };
+    }
+}

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -3747,8 +3747,11 @@ namespace LightInject
                 if (registrations.Count > 1)
                 {
                     var serviceNames = registrations.Keys.OrderBy(k => k).ToArray();
-                    var defaultServiceName = string.Empty;
                     serviceName = options.DefaultServiceSelector(serviceNames);
+                }
+                else
+                {
+                    serviceName = string.Empty;
                 }
             }
 


### PR DESCRIPTION
Fixed issue #578 and updated the unit tests that call `CanGetInstance` to cover null, empty, and whitespace values for the `serviceName` argument.