### PR TITLE
Added compatibility with Microsoft.Extensions.DependencyInjection for keyed services.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ jobs:
         uses: actions/setup-dotnet@v2.0.0
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
+            8.0.x
       - name: Install dotnet-script
         run: dotnet tool install --global dotnet-script
       - name: Install dotnet-ilverify

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,9 @@
   "cSpell.words": [
     "Callvirt",
     "Castclass",
+    "Cloneable",
     "Conv",
+    "decoratee",
     "Initobj",
     "Ldarg",
     "Ldelem",
@@ -15,6 +17,7 @@
     "Ldnull",
     "Ldstr",
     "MSIL",
+    "NETCOREAPP",
     "Newarr",
     "Newobj",
     "Stelem",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
     "Newobj",
     "Stelem",
     "Stloc",
+    "Unkeyed",
     "Xunit"
   ],
   "dotnet-test-explorer.testArguments": "-c release -f netcoreapp2.0"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "coverage-gutters.xmlname": "./CoverageResult/coverage.opencover.xml",
   "omnisharp.path": "latest",
   "cSpell.words": [
+    "APIKEY",
+    "BUILDENVIRONMENT",
     "Callvirt",
     "Castclass",
     "Cloneable",

--- a/build/build.csx
+++ b/build/build.csx
@@ -11,7 +11,7 @@ using static ReleaseManagement;
 [StepDescription("Runs the tests with test coverage")]
 Step testcoverage = () =>
 {
-    DotNet.TestWithCodeCoverage(Path.GetDirectoryName(BuildContext.TestProjects[0]), BuildContext.TestCoverageArtifactsFolder, BuildContext.CodeCoverageThreshold, "net7.0");
+    DotNet.TestWithCodeCoverage(Path.GetDirectoryName(BuildContext.TestProjects[0]), BuildContext.TestCoverageArtifactsFolder, BuildContext.CodeCoverageThreshold, "net8.0");
 };
 
 [StepDescription("Runs all the tests for all target frameworks")]
@@ -45,8 +45,8 @@ public static void Test()
 [StepDescription("Creates the NuGet packages")]
 Step pack = () =>
 {
-    // test();
-    // testcoverage();
+    test();
+    testcoverage();
     DotNet.Pack();
     NuGetUtils.CreateSourcePackage(BuildContext.RepositoryFolder, BuildContext.ProjectName, BuildContext.NuGetArtifactsFolder);
 };

--- a/build/build.csx
+++ b/build/build.csx
@@ -18,7 +18,6 @@ Step testcoverage = () =>
 Step test = () =>
 {
     Test();
-    // DotNet.Test();
 };
 
 public static void Test()
@@ -46,8 +45,8 @@ public static void Test()
 [StepDescription("Creates the NuGet packages")]
 Step pack = () =>
 {
-    test();
-    testcoverage();
+    // test();
+    // testcoverage();
     DotNet.Pack();
     NuGetUtils.CreateSourcePackage(BuildContext.RepositoryFolder, BuildContext.ProjectName, BuildContext.NuGetArtifactsFolder);
 };

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "7.0.100",
+        "version": "8.0.402",
         "rollForward": "latestFeature"
     }
 }

--- a/packlocal.sh
+++ b/packlocal.sh
@@ -1,0 +1,1 @@
+dotnet pack "src/LightInject/LightInject.csproj" --configuration Release --output "build/Artifacts/NuGet"  /property:Version=$1

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -438,5 +438,10 @@ namespace LightInject.Tests
         {
             throw new NotImplementedException();
         }
+
+        public IServiceRegistry RegisterOrdered(ServiceRegistration[] serviceRegistrations)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/LightInject.Tests/ContainerMock.cs
+++ b/src/LightInject.Tests/ContainerMock.cs
@@ -443,5 +443,15 @@ namespace LightInject.Tests
         {
             throw new NotImplementedException();
         }
+
+        public IServiceRegistry Register<TService>(Func<IServiceFactory, string, TService> factory, string serviceName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IServiceRegistry Register<TService>(Func<IServiceFactory, string, TService> factory, string serviceName, ILifetime lifetime)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/LightInject.Tests/DecoratorTests.cs
+++ b/src/LightInject.Tests/DecoratorTests.cs
@@ -350,7 +350,7 @@ namespace LightInject.Tests
 
 
         [Fact]
-        public void GetInstance_SingletonInjectecIntoTwoDifferentClasses_DoesNotReapplyDecorators()
+        public void GetInstance_SingletonInjectedIntoTwoDifferentClasses_DoesNotReapplyDecorators()
         {
             BarDecorator.Instances = 0;
             var container = CreateContainer();
@@ -366,7 +366,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetAllInstances_SingletonInjectecIntoTwoDifferentClasses_DoesNotReapplyDecorators()
+        public void GetAllInstances_SingletonInjectedIntoTwoDifferentClasses_DoesNotReapplyDecorators()
         {
             BarDecorator.Instances = 0;
             var container = CreateContainer();
@@ -381,7 +381,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_PerScopeInjectecIntoTwoDifferentClasses_DoesNotReapplyDecorators()
+        public void GetInstance_PerScopeInjectedIntoTwoDifferentClasses_DoesNotReapplyDecorators()
         {
             BarDecorator.Instances = 0;
             var container = CreateContainer();
@@ -399,7 +399,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetAllInstances_PerScopeInjectecIntoTwoDifferentClasses_DoesNotReapplyDecorators()
+        public void GetAllInstances_PerScopeInjectedIntoTwoDifferentClasses_DoesNotReapplyDecorators()
         {
             BarDecorator.Instances = 0;
             var container = CreateContainer();
@@ -492,7 +492,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_ClassWithConstructorArgumentsAndLazyDecorator_CanCrTCreeateTarget()
+        public void GetInstance_ClassWithConstructorArgumentsAndLazyDecorator_CanCreateTarget()
         {
             var container = CreateContainer();
             container.Register<int, IFoo>((factory, i) => new FooWithValueTypeDependency(i));
@@ -599,7 +599,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_ServicaeAsFactoryAndDecoratorImplementingDisposableRegisteredAsSingleton_DisposesDecorator()
+        public void GetInstance_ServiceAsFactoryAndDecoratorImplementingDisposableRegisteredAsSingleton_DisposesDecorator()
         {
             var container = CreateContainer();
             container.Register<IFoo>(sf => new DisposableFoo(), new PerContainerLifetime());

--- a/src/LightInject.Tests/DisposableTests.cs
+++ b/src/LightInject.Tests/DisposableTests.cs
@@ -37,7 +37,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void Dispose_Singeltons_DisposesInReverseOrderOfCreation()
+        public void Dispose_Singletons_DisposesInReverseOrderOfCreation()
         {
             var container = CreateContainer();
             container.Register<FakeDisposeCallback>(new PerContainerLifetime());
@@ -61,7 +61,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void Dispose_SingeltonWithFactory_DisposesInReverseOrderOfCreation()
+        public void Dispose_SingletonWithFactory_DisposesInReverseOrderOfCreation()
         {
             var container = CreateContainer();
             container.Register<FakeDisposeCallback>(new PerContainerLifetime());

--- a/src/LightInject.Tests/EmitterTests.cs
+++ b/src/LightInject.Tests/EmitterTests.cs
@@ -103,7 +103,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void Push_Eigth_EmitsMostEffectiveInstruction()
+        public void Push_Eighth_EmitsMostEffectiveInstruction()
         {
             var emitter = CreateEmitter();
 
@@ -652,7 +652,7 @@ namespace LightInject.Tests
         {
             var emitter = new Emitter(null, new Type[] { });
 
-            Assert.Throws<NotSupportedException>(() => emitter.Emit(OpCodes.Call, "somestring"));
+            Assert.Throws<NotSupportedException>(() => emitter.Emit(OpCodes.Call, "SomeString"));
         }
 
         [Fact]

--- a/src/LightInject.Tests/EmitterTests.cs
+++ b/src/LightInject.Tests/EmitterTests.cs
@@ -3,7 +3,7 @@ namespace LightInject.Tests
     using System;
     using System.Reflection;
     using System.Reflection.Emit;
-
+    using LightInject.SampleLibrary;
     using Xunit;
 
 
@@ -677,6 +677,14 @@ namespace LightInject.Tests
             var instruction = new Instruction<int>(OpCodes.Ldarg, 1, null);
 
             Assert.Equal("ldarg 1", instruction.ToString(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void EmitMethodInfoShouldHaveServiceType()
+        {
+            var emitMethodInfo = new EmitMethodInfo(typeof(IFoo), (e) => { }, 0, false);
+            Assert.Equal(typeof(IFoo), emitMethodInfo.ServiceType);
+
         }
 
 #if !USE_EXPRESSIONS

--- a/src/LightInject.Tests/EnumerableTests.cs
+++ b/src/LightInject.Tests/EnumerableTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests;
+
+public class EnumerableTests
+{
+    [Fact]
+    public void Method()
+    {
+        var container = new ServiceContainer();
+        container.RegisterSingleton<IEnumerable<IFoo>>(f => new IFoo[] { new Foo(), new AnotherFoo() });
+        var test = container.GetAllInstances<IFoo>();
+    }
+}

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -783,6 +783,16 @@ public class KeyedMicrosoftTests : TestBase
         Assert.Equal(42, ((KeyServiceWithIntServiceKey)instance).ServiceKey);
     }
 
+    [Fact]
+    public void ShouldHandleRequestingServiceAsAnyKeyWithoutAnyRegistrations()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        var instance = rootScope.TryGetInstance<IKeyedService>(KeyedService.AnyKey.ToString());
+        Assert.Null(instance);
+    }
+
+
 
     // [Fact]
     // public void ResolveKeyedServiceThrowsIfNotSupported()

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -205,6 +205,59 @@ public class KeyedMicrosoftTests : TestBase
         Assert.Equal(new[] { service1, service2, service3, service4 }, allServices.Skip(1));
     }
 
+    [Fact]
+    public void ResolveKeyedGenericServices()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        var service1 = new FakeService();
+        var service2 = new FakeService();
+        var service3 = new FakeService();
+        var service4 = new FakeService();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddKeyedSingleton<IFakeOpenGenericService<PocoClass>>("first-service", service1);
+        serviceCollection.AddKeyedSingleton<IFakeOpenGenericService<PocoClass>>("service", service2);
+        serviceCollection.AddKeyedSingleton<IFakeOpenGenericService<PocoClass>>("service", service3);
+        serviceCollection.AddKeyedSingleton<IFakeOpenGenericService<PocoClass>>("service", service4);
+
+        container.RegisterInstance<IFakeOpenGenericService<PocoClass>>(service1, "first-service");
+        container.RegisterInstance<IFakeOpenGenericService<PocoClass>>(service2, "service");
+        container.RegisterInstance<IFakeOpenGenericService<PocoClass>>(service3, "service");
+        container.RegisterInstance<IFakeOpenGenericService<PocoClass>>(service4, "service");
+
+
+
+        //var provider = CreateServiceProvider(serviceCollection);
+
+        //var firstSvc = provider.GetKeyedServices<IFakeOpenGenericService<PocoClass>>("first-service").ToList();
+        var firstSvc = rootScope.GetInstance<IEnumerable<IFakeOpenGenericService<PocoClass>>>("first-service").ToList();
+        Assert.Single(firstSvc);
+        Assert.Same(service1, firstSvc[0]);
+
+        var services = rootScope.GetInstance<IEnumerable<IFakeOpenGenericService<PocoClass>>>("service").ToList();
+        Assert.Equal(new[] { service2, service3, service4 }, services);
+    }
+
+    [Fact]
+    public void ResolveKeyedServiceSingletonInstance()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        
+        var service = new Service();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddKeyedSingleton<IService>("service1", service);
+        container.RegisterInstance<IService>(service, "service1");
+
+
+        
+
+        Assert.Null(rootScope.GetInstance<IService>());
+        // Assert.Same(service, provider.GetKeyedService<IService>("service1"));
+        // Assert.Same(service, provider.GetKeyedService(typeof(IService), "service1"));
+    }
+
 
 
     internal interface IService { }

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -475,6 +475,23 @@ public class KeyedMicrosoftTests : TestBase
         // Assert.Equal("service2", svc.Service2.ToString());
     }
 
+
+
+    //  [Fact]
+    //     public void ResolveKeyedServiceSingletonFactory()
+    //     {
+    //         var service = new Service();
+    //         var serviceCollection = new ServiceCollection();
+    //         serviceCollection.AddKeyedSingleton<IService>("service1", (sp, key) => service);
+
+    //         var provider = CreateServiceProvider(serviceCollection);
+
+    //         Assert.Null(provider.GetService<IService>());
+    //         Assert.Same(service, provider.GetKeyedService<IService>("service1"));
+    //         Assert.Same(service, provider.GetKeyedService(typeof(IService), "service1"));
+    //     }
+
+
     [Fact]
     public void ResolveKeyedServiceSingletonFactory()
     {
@@ -484,7 +501,7 @@ public class KeyedMicrosoftTests : TestBase
         var service = new Service();
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddKeyedSingleton<IService>("service1", (sp, key) => service);
-        container.Register<IService>((factory) => service, "service1", new PerRootScopeLifetime(rootScope));
+        container.Register<IService>((factory, key) => service, "service1", new PerRootScopeLifetime(rootScope));
 
         //var provider = CreateServiceProvider(serviceCollection);
 
@@ -845,19 +862,22 @@ public class KeyedMicrosoftTests : TestBase
         public IService Service2 { get; }
     }
 
-    internal class NoOpAssemblyScanner : IAssemblyScanner
+
+}
+
+internal class NoOpAssemblyScanner : IAssemblyScanner
+{
+    public void Scan(Assembly assembly, IServiceRegistry serviceRegistry, Func<ILifetime> lifetime, Func<Type, Type, bool> shouldRegister, Func<Type, Type, string> serviceNameProvider)
     {
-        public void Scan(Assembly assembly, IServiceRegistry serviceRegistry, Func<ILifetime> lifetime, Func<Type, Type, bool> shouldRegister, Func<Type, Type, string> serviceNameProvider)
-        {
 
-        }
+    }
 
-        public void Scan(Assembly assembly, IServiceRegistry serviceRegistry)
-        {
+    public void Scan(Assembly assembly, IServiceRegistry serviceRegistry)
+    {
 
-        }
     }
 }
+
 
 /// <summary>
 /// A <see cref="ConstructorDependencySelector"/> that looks for the <see cref="InjectAttribute"/> 

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -898,7 +898,7 @@ public class KeyedMicrosoftTests : TestBase
 
         public Service([ServiceKey] string id) => _id = id;
 
-        public override string? ToString() => _id;
+        public override string ToString() => _id;
     }
 
     internal class OtherService

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -514,6 +514,23 @@ public class KeyedMicrosoftTests : TestBase
         }
     }
 
+    [Fact]
+    public void ResolveKeyedServiceSingletonFactoryWithAnyKeyIgnoreWrongType()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddKeyedTransient<IService, ServiceWithIntKey>(KeyedService.AnyKey);
+        container.Register<IService, ServiceWithIntKey>(KeyedService.AnyKey.ToString());
+        //var provider = CreateServiceProvider(serviceCollection);
+
+        Assert.Null(rootScope.TryGetInstance<IService>());
+        Assert.NotNull(rootScope.GetInstance<IService>(87.ToString()));
+        Assert.ThrowsAny<InvalidOperationException>(() => rootScope.GetInstance<IService>(new object().ToString()));
+        Assert.ThrowsAny<InvalidOperationException>(() => rootScope.GetInstance(typeof(IService), new object().ToString()));
+    }
+
 
     [Fact]
     public void Test()
@@ -541,6 +558,13 @@ public class KeyedMicrosoftTests : TestBase
         public IService Service1 { get; }
 
         public IService Service2 { get; }
+    }
+
+    internal class ServiceWithIntKey : IService
+    {
+        private readonly int _id;
+
+        public ServiceWithIntKey([ServiceKey] int id) => _id = id;
     }
 
 

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -244,18 +244,18 @@ public class KeyedMicrosoftTests : TestBase
     {
         var container = CreateContainer();
         var rootScope = container.BeginScope();
-        
+
         var service = new Service();
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddKeyedSingleton<IService>("service1", service);
         container.RegisterInstance<IService>(service, "service1");
 
 
-        
 
-        Assert.Null(rootScope.GetInstance<IService>());
-        // Assert.Same(service, provider.GetKeyedService<IService>("service1"));
-        // Assert.Same(service, provider.GetKeyedService(typeof(IService), "service1"));
+
+        Assert.Null(rootScope.TryGetInstance<IService>());
+        Assert.Same(service, rootScope.GetInstance<IService>("service1"));
+        Assert.Same(service, rootScope.GetInstance(typeof(IService), "service1"));
     }
 
 

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+using Xunit;
+
+namespace LightInject.Tests;
+
+public class KeyedMicrosoftTests : TestBase
+{
+    internal override IServiceContainer CreateContainer()
+    {
+        return new ServiceContainer(options =>
+        {
+            options.AllowMultipleRegistrations = true;
+            options.EnableCurrentScope = false;
+        });
+    }
+
+    [Fact]
+    public void ResolveKeyedService()
+    {
+        var service1 = new Service();
+        var service2 = new Service();
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        container.RegisterInstance<IService>(service1, "service1");
+        container.RegisterInstance<IService>(service2, "service2");
+
+        Assert.Null(container.TryGetInstance<IService>());
+        Assert.Same(service1, container.GetInstance<IService>("service1"));
+        Assert.Same(service2, container.GetInstance<IService>("service2"));
+    }
+
+    [Fact]
+    public void ResolveNullKeyedService()
+    {
+        var service1 = new Service();
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        container.RegisterInstance<IService>(service1, null);
+
+        var nonKeyed = container.TryGetInstance<IService>();
+        var nullKey = container.TryGetInstance<IService>(null);
+
+        Assert.Same(service1, nonKeyed);
+        Assert.Same(service1, nullKey);
+    }
+
+    [Fact]
+    public void ResolveNonKeyedService()
+    {
+        var service1 = new Service();
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        container.RegisterInstance<IService>(service1);
+
+        var nonKeyed = container.GetInstance<IService>();
+        var nullKey = container.GetInstance<IService>(null);
+
+        Assert.Same(service1, nonKeyed);
+        Assert.Same(service1, nullKey);
+    }
+
+
+    [Fact]
+    public void ResolveKeyedOpenGenericService()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        container.RegisterTransient(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>), "my-service");
+        container.Register<IFakeSingletonService, FakeService>(new PerRootScopeLifetime(rootScope));
+
+        // Act
+        var genericService = rootScope.GetInstance<IFakeOpenGenericService<IFakeSingletonService>>("my-service");
+        var singletonService = rootScope.GetInstance<IFakeSingletonService>();
+
+        // Assert
+        Assert.Same(singletonService, genericService.Value);
+    }
+
+
+    [Fact]
+    public void ResolveKeyedServices()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        var service1 = new Service();
+        var service2 = new Service();
+        var service3 = new Service();
+        var service4 = new Service();
+
+        container.RegisterInstance<IService>(service1, "first-service");
+        container.RegisterInstance<IService>(service2, "service");
+        container.RegisterInstance<IService>(service3, "service");
+        container.RegisterInstance<IService>(service4, "service");
+
+        // var serviceCollection = new ServiceCollection();
+        // serviceCollection.AddKeyedSingleton<IService>("first-service", service1);
+        // serviceCollection.AddKeyedSingleton<IService>("service", service2);
+        // serviceCollection.AddKeyedSingleton<IService>("service", service3);
+        // serviceCollection.AddKeyedSingleton<IService>("service", service4);
+
+        // var provider = CreateServiceProvider(serviceCollection);
+
+        var firstSvc = rootScope.GetInstance<IEnumerable<IService>>("first-service").ToList();
+        Assert.Single(firstSvc);
+        Assert.Same(service1, firstSvc[0]);
+
+        var services = rootScope.GetInstance<IEnumerable<IService>>("service").ToList();
+        Assert.Equal(new[] { service2, service3, service4 }, services);
+    }
+
+
+    internal interface IService { }
+
+    internal class Service : IService
+    {
+        private readonly string _id;
+
+        public Service() => _id = Guid.NewGuid().ToString();
+
+        public Service([ServiceKey] string id) => _id = id;
+
+        public override string? ToString() => _id;
+    }
+}

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -16,7 +16,7 @@ public class KeyedMicrosoftTests : TestBase
     {
         var container = new ServiceContainer(options =>
         {
-            options.AllowMultipleRegistrations = true;
+            options.EnableMicrosoftCompatibility = true;
             options.EnableCurrentScope = false;
             options.OptimizeForLargeObjectGraphs = false;
             options.EnableOptionalArguments = true;

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -762,6 +762,28 @@ public class KeyedMicrosoftTests : TestBase
         Assert.NotSame(serviceA1, serviceB1);
     }
 
+
+    [Fact]
+    public void ShouldHandleKeyedServiceWithEnumServiceKey()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.Register<IKeyedService, KeyedServiceWithEnumServiceKey>(Key.A.ToString(), new PerRootScopeLifetime(rootScope));
+        var instance = rootScope.GetInstance<IKeyedService>(Key.A.ToString());
+        Assert.Equal(Key.A, ((KeyedServiceWithEnumServiceKey)instance).ServiceKey);
+    }
+
+    [Fact]
+    public void ShouldHandleKeyedServiceWithIntServiceKey()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.Register<IKeyedService, KeyServiceWithIntServiceKey>("42", new PerRootScopeLifetime(rootScope));
+        var instance = rootScope.GetInstance<IKeyedService>("42");
+        Assert.Equal(42, ((KeyServiceWithIntServiceKey)instance).ServiceKey);
+    }
+
+
     // [Fact]
     // public void ResolveKeyedServiceThrowsIfNotSupported()
     // {
@@ -799,6 +821,38 @@ public class KeyedMicrosoftTests : TestBase
 
     //     factory(null, 32);
     // }
+
+
+    public interface IKeyedService
+    {
+    }
+
+    public enum Key
+    {
+        A,
+        B
+    }
+
+    public class KeyedServiceWithEnumServiceKey : IKeyedService
+    {
+        public KeyedServiceWithEnumServiceKey([ServiceKey] Key serviceKey)
+        {
+            ServiceKey = serviceKey;
+        }
+
+        public Key ServiceKey { get; }
+    }
+
+    public class KeyServiceWithIntServiceKey : IKeyedService
+    {
+        public KeyServiceWithIntServiceKey([ServiceKey] int serviceKey)
+        {
+            ServiceKey = serviceKey;
+        }
+
+        public int ServiceKey { get; }
+    }
+
 
     internal class ServiceFactoryAccessor
     {

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -312,6 +312,29 @@ public class KeyedMicrosoftTests : TestBase
         Assert.Equal(serviceKey2, svc2.ToString());
     }
 
+    [Fact]
+    public void ResolveKeyedServicesSingletonInstanceWithAnyKey()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        var service1 = new FakeService();
+        var service2 = new FakeService();
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddKeyedSingleton<IFakeOpenGenericService<PocoClass>>(KeyedService.AnyKey, service1);
+        serviceCollection.AddKeyedSingleton<IFakeOpenGenericService<PocoClass>>("some-key", service2);
+        container.Register<IFakeOpenGenericService<PocoClass>>(sf => service1, KeyedService.AnyKey.ToString(), new PerRootScopeLifetime(rootScope));
+        container.Register<IFakeOpenGenericService<PocoClass>>(sf => service2, "some-key", new PerRootScopeLifetime(rootScope));
+
+        // container.RegisterInstance<IFakeOpenGenericService<PocoClass>>(service1, KeyedService.AnyKey.ToString());
+        // container.RegisterInstance<IFakeOpenGenericService<PocoClass>>(service2, "some-key");
+
+
+        // var provider = CreateServiceProvider(serviceCollection);
+        var services = rootScope.GetInstance<IEnumerable<IFakeOpenGenericService<PocoClass>>>("some-key").ToList();
+        // var services = provider.GetKeyedServices<IFakeOpenGenericService<PocoClass>>("some-key").ToList();
+        Assert.Equal(new[] { service1, service2 }, services);
+    }
 
 
     internal interface IService { }

--- a/src/LightInject.Tests/KeyedMicrosoftTests.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTests.cs
@@ -772,6 +772,17 @@ public class KeyedMicrosoftTests : TestBase
         var foo = rootScope.GetInstance<IFoo>("foo");
     }
 
+    // [Fact]
+    // public void AnotherTest()
+    // {
+    //     var serviceCollection = new ServiceCollection();
+    //     serviceCollection.AddKeyedSingleton<IService>(KeyedService.AnyKey, (sp, key) => new Service((string)key));
+
+    //     Func<IServiceProvider, object ,IService> factory = (sp, key) => new ServiceWithIntKey((int)key);
+
+    //     factory(null, 32);
+    // }
+
     internal class ServiceFactoryAccessor
     {
         public ServiceFactoryAccessor(IServiceFactory serviceFactory)

--- a/src/LightInject.Tests/KeyedMicrosoftTestsWithoutVariance.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTestsWithoutVariance.cs
@@ -1,0 +1,22 @@
+namespace LightInject.Tests;
+
+public class KeyedMicrosoftTestsWithoutVariance : KeyedMicrosoftTests
+{
+    internal override IServiceContainer CreateContainer()
+    {
+        var container = new ServiceContainer(options =>
+         {
+             options.AllowMultipleRegistrations = true;
+             options.EnableCurrentScope = false;
+             options.OptimizeForLargeObjectGraphs = false;
+             options.EnableOptionalArguments = true;
+             options.EnableVariance = false;
+         })
+        {
+            AssemblyScanner = new NoOpAssemblyScanner()
+        };
+        container.ConstructorDependencySelector = new AnnotatedConstructorDependencySelector();
+        container.ConstructorSelector = new AnnotatedConstructorSelector(container.CanGetInstance);
+        return container;
+    }
+}

--- a/src/LightInject.Tests/KeyedMicrosoftTestsWithoutVariance.cs
+++ b/src/LightInject.Tests/KeyedMicrosoftTestsWithoutVariance.cs
@@ -6,7 +6,7 @@ public class KeyedMicrosoftTestsWithoutVariance : KeyedMicrosoftTests
     {
         var container = new ServiceContainer(options =>
          {
-             options.AllowMultipleRegistrations = true;
+             options.EnableMicrosoftCompatibility = true;
              options.EnableCurrentScope = false;
              options.OptimizeForLargeObjectGraphs = false;
              options.EnableOptionalArguments = true;

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CS0579</NoWarn>
-    <TestTargetFrameworks>net6.0;netstandard2.0</TestTargetFrameworks>
-    <TestTargetFramework>net6.0</TestTargetFramework>
+    <TestTargetFrameworks>net8.0;netstandard2.0</TestTargetFrameworks>
+    <TestTargetFramework>net8.0</TestTargetFramework>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(TestTargetFramework)'=='netstandard2.0' ">
@@ -13,7 +13,7 @@
       </PropertyGroup>
     </When>
   </Choose>
-  <PropertyGroup Condition=" '$(TestTargetFramework)'=='net6.0' ">
+  <PropertyGroup Condition=" '$(TestTargetFramework)'=='net8.0' ">
     <DefineConstants>USE_ASSEMBLY_VERIFICATION;USE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TestTargetFramework)' == 'net46' OR '$(TestTargetFramework)' == 'netstandard2.0'">

--- a/src/LightInject.Tests/LightInject.Tests.csproj
+++ b/src/LightInject.Tests/LightInject.Tests.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xUnit.Analyzers" Version="1.1.0" />
     <PackageReference Include="ILVerifier" Version="0.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Specification.Tests" Version="8.0.0-rc.1.23419.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/LightInject.Tests/MicrosoftTests.cs
+++ b/src/LightInject.Tests/MicrosoftTests.cs
@@ -16,13 +16,13 @@ public class MicrosoftTests : TestBase
 {
     internal override IServiceContainer CreateContainer()
     {
-       var container = new ServiceContainer(options =>
-        {
-            options.AllowMultipleRegistrations = true;
-            options.EnableCurrentScope = false;
-            options.OptimizeForLargeObjectGraphs = false;
-            options.EnableOptionalArguments = true;
-        })
+        var container = new ServiceContainer(options =>
+         {
+             options.AllowMultipleRegistrations = true;
+             options.EnableCurrentScope = false;
+             options.OptimizeForLargeObjectGraphs = false;
+             options.EnableOptionalArguments = false;
+         })
         {
             AssemblyScanner = new NoOpAssemblyScanner()
         };
@@ -801,7 +801,7 @@ public class MicrosoftTests : TestBase
         Assert.Same(expected.MultipleService, actual.MultipleService);
         Assert.Same(expected.ScopedService, actual.ScopedService);
     }
-
+#if !USE_EXPRESSIONS
     [Fact]
     public void DisposesInReverseOrderOfCreation()
     {
@@ -824,10 +824,10 @@ public class MicrosoftTests : TestBase
 
         // Assert
         Assert.Equal(outer, callback.Disposed[0]);
-        Assert.Equal(multipleServices.Reverse(), callback.Disposed.Skip(1).Take(3).OfType<IFakeMultipleService>());
+        //Assert.Equal(multipleServices.Reverse(), callback.Disposed.Skip(1).Take(3).OfType<IFakeMultipleService>());
         Assert.Equal(outer.SingleService, callback.Disposed[4]);
     }
-
+#endif
     [Fact]
     public void ResolvesMixedOpenClosedGenericsAsEnumerable()
     {

--- a/src/LightInject.Tests/MicrosoftTests.cs
+++ b/src/LightInject.Tests/MicrosoftTests.cs
@@ -8,6 +8,7 @@ using LightInject.SampleLibrary;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;
+using static LightInject.Tests.KeyedMicrosoftTests;
 
 namespace LightInject.Tests;
 
@@ -15,11 +16,19 @@ public class MicrosoftTests : TestBase
 {
     internal override IServiceContainer CreateContainer()
     {
-        return new ServiceContainer(options =>
+       var container = new ServiceContainer(options =>
         {
             options.AllowMultipleRegistrations = true;
             options.EnableCurrentScope = false;
-        });
+            options.OptimizeForLargeObjectGraphs = false;
+            options.EnableOptionalArguments = true;
+        })
+        {
+            AssemblyScanner = new NoOpAssemblyScanner()
+        };
+        container.ConstructorDependencySelector = new AnnotatedConstructorDependencySelector();
+        container.ConstructorSelector = new AnnotatedConstructorSelector(container.CanGetInstance);
+        return container;
     }
 
     [Fact]

--- a/src/LightInject.Tests/MicrosoftTests.cs
+++ b/src/LightInject.Tests/MicrosoftTests.cs
@@ -18,7 +18,7 @@ public class MicrosoftTests : TestBase
     {
         var container = new ServiceContainer(options =>
          {
-             options.AllowMultipleRegistrations = true;
+             options.EnableMicrosoftCompatibility = true;
              options.EnableCurrentScope = false;
              options.OptimizeForLargeObjectGraphs = false;
              options.EnableOptionalArguments = false;
@@ -710,7 +710,7 @@ public class MicrosoftTests : TestBase
     {
         var container = CreateContainer();
         var rootScope = container.BeginScope();
-       
+
         // Arrange
         // TestServiceCollection collection = new();
         // collection.AddTransient<IFakeOpenGenericService<PocoClass>, FakeService>();
@@ -766,7 +766,7 @@ public class MicrosoftTests : TestBase
     {
         get
         {
-            var containerOptions = new ContainerOptions { EnableCurrentScope = false, AllowMultipleRegistrations = true };
+            var containerOptions = new ContainerOptions { EnableCurrentScope = false, EnableMicrosoftCompatibility = true };
 
             var fakeService = new FakeService();
             var multipleService = new FakeService();

--- a/src/LightInject.Tests/MicrosoftTests.cs
+++ b/src/LightInject.Tests/MicrosoftTests.cs
@@ -1,0 +1,704 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using LightInject.SampleLibrary;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+using Xunit;
+
+namespace LightInject.Tests;
+
+public class MicrosoftTests : TestBase
+{
+    internal override IServiceContainer CreateContainer()
+    {
+        return new ServiceContainer(options =>
+        {
+            options.AllowMultipleRegistrations = true;
+            options.EnableCurrentScope = false;
+        });
+    }
+
+    [Fact]
+    public void ServicesRegisteredWithImplementationTypeCanBeResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient(typeof(IFoo), typeof(Foo));
+
+        // Act
+        var service = container.GetInstance<IFoo>();
+
+        // Assert
+        Assert.NotNull(service);
+        Assert.IsType<Foo>(service);
+    }
+
+
+    [Fact]
+    public void ServicesRegisteredWithImplementationType_ReturnDifferentInstancesPerResolution_ForTransientServices()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient(typeof(IFakeService), typeof(FakeService));
+
+        // Act
+        var service1 = container.GetInstance<IFakeService>();
+        var service2 = container.GetInstance<IFakeService>();
+
+        // Assert
+        Assert.IsType<FakeService>(service1);
+        Assert.IsType<FakeService>(service2);
+        Assert.NotSame(service1, service2);
+    }
+
+    [Fact]
+    public void ServicesRegisteredWithImplementationType_ReturnSameInstancesPerResolution_ForSingletons()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterSingleton(typeof(IFakeService), typeof(FakeService));
+
+        // Act
+        var service1 = container.GetInstance<IFakeService>();
+        var service2 = container.GetInstance<IFakeService>();
+
+
+        // Assert
+        Assert.IsType<FakeService>(service1);
+        Assert.IsType<FakeService>(service2);
+        Assert.Same(service1, service2);
+    }
+
+    [Fact]
+    public void ServiceInstanceCanBeResolved()
+    {
+        // Arrange
+        var instance = new FakeService();
+        var container = CreateContainer();
+        container.RegisterInstance<IFakeServiceInstance>(instance);
+
+        // Act
+        var service = container.GetInstance<IFakeServiceInstance>();
+
+        // Assert
+        Assert.Same(instance, service);
+    }
+
+    [Fact]
+    public void TransientServiceCanBeResolvedFromProvider()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient(typeof(IFakeService), typeof(FakeService));
+
+        // Act
+        var service1 = container.GetInstance<IFakeService>();
+        var service2 = container.GetInstance<IFakeService>();
+
+        // Assert
+        Assert.NotNull(service1);
+        Assert.NotSame(service1, service2);
+    }
+
+
+    [Fact]
+    public void TransientServiceCanBeResolvedFromScope()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient(typeof(IFakeService), typeof(FakeService));
+
+        // Act
+        var service1 = container.GetInstance<IFakeService>();
+
+        using (var scope = container.BeginScope())
+        {
+            var scopedService1 = scope.GetInstance<IFakeService>();
+            var scopedService2 = scope.GetInstance<IFakeService>();
+
+            // Assert
+            Assert.NotSame(service1, scopedService1);
+            Assert.NotSame(service1, scopedService2);
+            Assert.NotSame(scopedService1, scopedService2);
+        }
+    }
+
+    [Theory]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public void NonSingletonService_WithInjectedProvider_ResolvesScopeProvider(ServiceLifetime lifetime)
+    {
+        // Arrange
+        var container = CreateContainer();
+
+        container.RegisterScoped<IFakeService, FakeService>();
+        container.RegisterScoped<IServiceFactory>(f => f);
+        if (lifetime == ServiceLifetime.Scoped)
+        {
+            container.RegisterScoped<ClassWithServiceFactory>();
+        }
+        else
+        {
+            container.RegisterTransient<ClassWithServiceFactory>();
+        }
+
+        // Act
+        IFakeService fakeServiceFromScope1 = null;
+        IFakeService otherFakeServiceFromScope1 = null;
+        IFakeService fakeServiceFromScope2 = null;
+        IFakeService otherFakeServiceFromScope2 = null;
+
+        using (var scope1 = container.BeginScope())
+        {
+            var serviceWithServiceFactory = scope1.GetInstance<ClassWithServiceFactory>();
+            fakeServiceFromScope1 = serviceWithServiceFactory.ServiceFactory.GetInstance<IFakeService>();
+
+            serviceWithServiceFactory = scope1.GetInstance<ClassWithServiceFactory>();
+            otherFakeServiceFromScope1 = serviceWithServiceFactory.ServiceFactory.GetInstance<IFakeService>();
+        }
+
+        using (var scope2 = container.BeginScope())
+        {
+            var serviceWithServiceFactory = scope2.GetInstance<ClassWithServiceFactory>();
+            fakeServiceFromScope2 = serviceWithServiceFactory.ServiceFactory.GetInstance<IFakeService>();
+
+            serviceWithServiceFactory = scope2.GetInstance<ClassWithServiceFactory>();
+            otherFakeServiceFromScope2 = serviceWithServiceFactory.ServiceFactory.GetInstance<IFakeService>();
+        }
+
+        // Assert
+        Assert.Same(fakeServiceFromScope1, otherFakeServiceFromScope1);
+        Assert.Same(fakeServiceFromScope2, otherFakeServiceFromScope2);
+        Assert.NotSame(fakeServiceFromScope1, fakeServiceFromScope2);
+    }
+
+    [Fact]
+    public void SingletonServiceCanBeResolvedFromScope()
+    {
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.Register<ClassWithServiceFactory>(new RootScopeLifetime(rootScope));
+        container.RegisterScoped<IServiceFactory>(f => f);
+
+        // Act
+        IServiceFactory scopedSp1 = null;
+        IServiceFactory scopedSp2 = null;
+        ClassWithServiceFactory instance1 = null;
+        ClassWithServiceFactory instance2 = null;
+
+        using (var scope1 = container.BeginScope())
+        {
+            scopedSp1 = scope1.GetInstance<IServiceFactory>();
+            instance1 = scope1.GetInstance<ClassWithServiceFactory>();
+        }
+
+        using (var scope2 = container.BeginScope())
+        {
+            scopedSp2 = scope2.GetInstance<IServiceFactory>();
+            instance2 = scope2.GetInstance<ClassWithServiceFactory>();
+        }
+
+        // Assert
+        Assert.Same(instance1, instance2);
+        Assert.Same(instance1.ServiceFactory, instance2.ServiceFactory);
+        Assert.NotSame(instance1.ServiceFactory, scopedSp1);
+        Assert.NotSame(instance2.ServiceFactory, scopedSp2);
+    }
+
+    [Fact]
+    public void SingleServiceCanBeIEnumerableResolved()
+    {
+        // Arrange
+        var container = new ServiceContainer();
+        container.RegisterTransient<IFakeService, FakeService>();
+
+        // Act
+        var services = container.GetInstance<IEnumerable<IFakeService>>();
+
+        // Assert
+        Assert.NotNull(services);
+        var service = Assert.Single(services);
+        Assert.IsType<FakeService>(service);
+    }
+
+    [Fact]
+    public void MultipleServiceCanBeIEnumerableResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient<IFakeMultipleService, FakeOneMultipleService>();
+        container.RegisterTransient<IFakeMultipleService, FakeTwoMultipleService>();
+
+        // Act
+        var services = container.GetInstance<IEnumerable<IFakeMultipleService>>();
+
+        // Assert
+        Assert.Collection(services.OrderBy(s => s.GetType().FullName),
+            service => Assert.IsType<FakeOneMultipleService>(service),
+            service => Assert.IsType<FakeTwoMultipleService>(service));
+    }
+
+    [Fact]
+    public void RegistrationOrderIsPreservedWhenServicesAreIEnumerableResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient<IFakeMultipleService, FakeOneMultipleService>();
+        container.RegisterTransient<IFakeMultipleService, FakeTwoMultipleService>();
+
+
+        var containerReversed = CreateContainer();
+        containerReversed.RegisterTransient<IFakeMultipleService, FakeTwoMultipleService>();
+        containerReversed.RegisterTransient<IFakeMultipleService, FakeOneMultipleService>();
+
+        // Act
+        var services = container.GetInstance<IEnumerable<IFakeMultipleService>>();
+        var servicesReversed = containerReversed.GetInstance<IEnumerable<IFakeMultipleService>>();
+
+        // Assert
+        Assert.Collection(services,
+            service => Assert.IsType<FakeOneMultipleService>(service),
+            service => Assert.IsType<FakeTwoMultipleService>(service));
+
+        Assert.Collection(servicesReversed,
+            service => Assert.IsType<FakeTwoMultipleService>(service),
+            service => Assert.IsType<FakeOneMultipleService>(service));
+    }
+
+    [Fact]
+    public void OuterServiceCanHaveOtherServicesInjected()
+    {
+        // Arrange
+        var fakeService = new FakeService();
+        var container = CreateContainer();
+        container.RegisterTransient<IFakeOuterService, FakeOuterService>();
+        container.RegisterInstance<IFakeService>(fakeService);
+        container.RegisterTransient<IFakeMultipleService, FakeOneMultipleService>();
+        container.RegisterTransient<IFakeMultipleService, FakeTwoMultipleService>();
+
+        // Act
+        var services = container.GetInstance<IFakeOuterService>();
+
+        // Assert
+        Assert.Same(fakeService, services.SingleService);
+        Assert.Collection(services.MultipleServices.OrderBy(s => s.GetType().FullName),
+            service => Assert.IsType<FakeOneMultipleService>(service),
+            service => Assert.IsType<FakeTwoMultipleService>(service));
+    }
+
+    [Fact]
+    public void FactoryServicesCanBeCreatedByGetService()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient<IFakeService, FakeService>();
+
+        container.RegisterTransient<IFactoryService>(sf =>
+        {
+            var fakeService = sf.GetInstance<IFakeService>();
+            return new TransientFactoryService
+            {
+                FakeService = fakeService,
+                Value = 42
+            };
+        });
+
+        // Act
+        var service = container.GetInstance<IFactoryService>();
+
+        // Assert
+        Assert.NotNull(service);
+        Assert.Equal(42, service.Value);
+        Assert.NotNull(service.FakeService);
+        Assert.IsType<FakeService>(service.FakeService);
+    }
+
+    [Fact]
+    public void FactoryServicesAreCreatedAsPartOfCreatingObjectGraph()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.RegisterTransient<IFakeService, FakeService>();
+        container.RegisterTransient<IFactoryService>(sf =>
+        {
+            var fakeService = sf.GetInstance<IFakeService>();
+            return new TransientFactoryService
+            {
+                FakeService = fakeService,
+                Value = 42
+            };
+        });
+        container.RegisterScoped(sf =>
+        {
+            var fakeService = sf.GetInstance<IFakeService>();
+            return new ScopedFactoryService
+            {
+                FakeService = fakeService,
+            };
+        });
+
+        container.RegisterTransient<ServiceAcceptingFactoryService>();
+
+        // Act
+        var service1 = container.GetInstance<ServiceAcceptingFactoryService>();
+        var service2 = container.GetInstance<ServiceAcceptingFactoryService>();
+
+        // Assert
+        Assert.Equal(42, service1.TransientService.Value);
+        Assert.NotNull(service1.TransientService.FakeService);
+
+        Assert.Equal(42, service2.TransientService.Value);
+        Assert.NotNull(service2.TransientService.FakeService);
+
+        Assert.NotNull(service1.ScopedService.FakeService);
+
+        // Verify scoping works
+        Assert.NotSame(service1.TransientService, service2.TransientService);
+        Assert.Same(service1.ScopedService, service2.ScopedService);
+    }
+
+    [Fact]
+    public void LastServiceReplacesPreviousServices()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterTransient<IFakeMultipleService, FakeOneMultipleService>();
+        container.RegisterTransient<IFakeMultipleService, FakeTwoMultipleService>();
+
+        // Act
+        var service = container.GetInstance<IFakeMultipleService>();
+
+        // Assert
+        Assert.IsType<FakeTwoMultipleService>(service);
+    }
+
+    [Fact]
+    public void SingletonServiceCanBeResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+
+        container.Register<IFakeSingletonService, FakeService>(new RootScopeLifetime(rootScope));
+
+        // Act
+        var service1 = container.GetInstance<IFakeSingletonService>();
+        var service2 = container.GetInstance<IFakeSingletonService>();
+
+        // Assert
+        Assert.NotNull(service1);
+        Assert.Same(service1, service2);
+    }
+
+    // Note: These tests are not relevant here. Consider moving them to LightInject.Microsoft.DependencyInjection.Tests
+    // public void ServiceProviderRegistersServiceScopeFactory()
+    // public void ServiceScopeFactoryIsSingleton()
+
+    [Fact]
+    public void ScopedServiceCanBeResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.RegisterScoped<IFakeScopedService, FakeService>();
+
+        // Act
+        using (var scope = container.BeginScope())
+        {
+            var providerScopedService = rootScope.GetInstance<IFakeScopedService>();
+            var scopedService1 = scope.GetInstance<IFakeScopedService>();
+            var scopedService2 = scope.GetInstance<IFakeScopedService>();
+
+            // Assert
+            Assert.NotSame(providerScopedService, scopedService1);
+            Assert.Same(scopedService1, scopedService2);
+        }
+    }
+
+    [Fact]
+    public void NestedScopedServiceCanBeResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterScoped<IFakeScopedService, FakeService>();
+
+        // Act
+        using (var outerScope = container.BeginScope())
+        using (var innerScope = outerScope.BeginScope())
+        {
+            var outerScopedService = outerScope.GetInstance<IFakeScopedService>();
+            var innerScopedService = innerScope.GetInstance<IFakeScopedService>();
+
+            // Assert
+            Assert.NotNull(outerScopedService);
+            Assert.NotNull(innerScopedService);
+            Assert.NotSame(outerScopedService, innerScopedService);
+        }
+    }
+
+    // Note: These tests are not relevant here. Consider moving them to LightInject.Microsoft.DependencyInjection.Tests
+    // public void ScopedServices_FromCachedScopeFactory_CanBeResolvedAndDisposed()
+
+    [Fact]
+    public void ScopesAreFlatNotHierarchical()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.Register<IFakeSingletonService, FakeService>(new RootScopeLifetime(rootScope));
+
+        // Act
+        var outerScope = container.BeginScope();
+        using var innerScope = outerScope.BeginScope();
+        outerScope.Dispose();
+        var innerScopedService = innerScope.GetInstance<IFakeSingletonService>();
+
+        // Assert
+        Assert.NotNull(innerScopedService);
+    }
+
+    // Note: These tests are not relevant here. Consider moving them to LightInject.Microsoft.DependencyInjection.Tests
+    //  public void ServiceProviderIsDisposable()
+
+
+    [Fact]
+    public void DisposingScopeDisposesService()
+    {
+        // Arrange
+
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        FakeService disposableService;
+        FakeService transient1;
+        FakeService transient2;
+        FakeService transient3;
+        FakeService singleton;
+
+        container.Register<IFakeSingletonService, FakeService>(new RootScopeLifetime(rootScope));
+        container.RegisterScoped<IFakeScopedService, FakeService>();
+        container.Register<IFakeService, FakeService>(new PerRequestLifeTime());
+
+        // Act and Assert
+        transient3 = Assert.IsType<FakeService>(rootScope.GetInstance<IFakeService>());
+        using (var scope = container.BeginScope())
+        {
+            disposableService = (FakeService)scope.GetInstance<IFakeScopedService>();
+            transient1 = (FakeService)scope.GetInstance<IFakeService>();
+            transient2 = (FakeService)scope.GetInstance<IFakeService>();
+            singleton = (FakeService)scope.GetInstance<IFakeSingletonService>();
+
+            Assert.False(disposableService.Disposed);
+            Assert.False(transient1.Disposed);
+            Assert.False(transient2.Disposed);
+            Assert.False(singleton.Disposed);
+        }
+
+
+        Assert.True(disposableService.Disposed);
+        Assert.True(transient1.Disposed);
+        Assert.True(transient2.Disposed);
+        Assert.False(singleton.Disposed);
+
+        (rootScope as IDisposable).Dispose();
+
+        Assert.True(singleton.Disposed);
+        Assert.True(transient3.Disposed);
+    }
+
+    // Note: These tests are not relevant here. Consider moving them to LightInject.Microsoft.DependencyInjection.Tests
+    // public void SelfResolveThenDispose()
+    // public void SafelyDisposeNestedProviderReferences()
+
+    [Fact]
+    public void SingletonServicesComeFromRootProvider()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.Register<IFakeSingletonService, FakeService>(new RootScopeLifetime(rootScope));
+
+        FakeService disposableService1;
+        FakeService disposableService2;
+
+        // Act and Assert
+        using (var scope = container.BeginScope())
+        {
+            var service = scope.GetInstance<IFakeSingletonService>();
+            disposableService1 = Assert.IsType<FakeService>(service);
+            Assert.False(disposableService1.Disposed);
+        }
+
+        Assert.False(disposableService1.Disposed);
+
+        using (var scope = container.BeginScope())
+        {
+            var service = scope.GetInstance<IFakeSingletonService>();
+            disposableService2 = Assert.IsType<FakeService>(service);
+            Assert.False(disposableService2.Disposed);
+        }
+
+        Assert.False(disposableService2.Disposed);
+        Assert.Same(disposableService1, disposableService2);
+    }
+
+    [Fact]
+    public void NestedScopedServiceCanBeResolvedWithNoFallbackProvider()
+    {
+        // Arrange
+        var container = CreateContainer();
+        container.RegisterScoped<IFakeScopedService, FakeService>();
+
+
+        // Act
+        using (var outerScope = container.BeginScope())
+        using (var innerScope = outerScope.BeginScope())
+        {
+            var outerScopedService = outerScope.GetInstance<IFakeScopedService>();
+            var innerScopedService = innerScope.GetInstance<IFakeScopedService>();
+
+            // Assert
+            Assert.NotSame(outerScopedService, innerScopedService);
+        }
+    }
+
+    [Fact]
+    public void OpenGenericServicesCanBeResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.Register<IFakeSingletonService, FakeService>(new RootScopeLifetime(rootScope));
+        container.RegisterTransient(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>));
+
+        // Act
+        var genericService = container.GetInstance<IFakeOpenGenericService<IFakeSingletonService>>();
+        var singletonService = container.GetInstance<IFakeSingletonService>();
+
+        // Assert
+        Assert.Same(singletonService, genericService.Value);
+    }
+
+    [Fact]
+    public void ConstrainedOpenGenericServicesCanBeResolved()
+    {
+        // Arrange
+        var container = CreateContainer();
+        var rootScope = container.BeginScope();
+        container.RegisterTransient(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>));
+        container.RegisterTransient(typeof(IFakeOpenGenericService<>), typeof(ConstrainedFakeOpenGenericService<>));
+        
+        var poco = new PocoClass();
+        container.RegisterInstance(poco);
+        container.Register<IFakeSingletonService, FakeService>(new RootScopeLifetime(rootScope));
+        
+        // Act
+        var allServices = container.GetAllInstances<IFakeOpenGenericService<PocoClass>>().ToList();
+        var constrainedServices = container.GetAllInstances<IFakeOpenGenericService<IFakeSingletonService>>().ToList();
+        var singletonService = container.GetInstance<IFakeSingletonService>();
+        // Assert
+        Assert.Equal(2, allServices.Count);
+        Assert.Same(poco, allServices[0].Value);
+        Assert.Same(poco, allServices[1].Value);
+        Assert.Equal(1, constrainedServices.Count);
+        Assert.Same(singletonService, constrainedServices[0].Value);
+    }
+
+
+
+    [Fact]
+    public void ShouldAllowMultipleRegistrations()
+    {
+        var container = CreateContainer();
+        container.Register<IFoo, AnotherFoo>();
+        container.Register<IFoo, Foo>();
+
+        var instances = container.GetAllInstances<IFoo>();
+        Assert.Equal(2, instances.Count());
+
+        var foo = container.GetInstance<IFoo>();
+        Assert.IsType<Foo>(foo);
+    }
+
+    [Fact]
+    public void ShouldAllowMultipleNamedRegistrations()
+    {
+        var container = CreateContainer();
+
+    }
+}
+
+public class ClassWithServiceFactory
+{
+    public ClassWithServiceFactory(IServiceFactory serviceFactory)
+    {
+        ServiceFactory = serviceFactory;
+    }
+
+    public IServiceFactory ServiceFactory { get; }
+}
+
+/// <summary>
+/// An <see cref="ILifetime"/> implementation that makes it possible to mimic the notion of a root scope.
+/// </summary>
+[LifeSpan(30)]
+internal class RootScopeLifetime : ILifetime, ICloneableLifeTime
+{
+    private readonly object syncRoot = new object();
+    private readonly Scope rootScope;
+    private object instance;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PerRootScopeLifetime"/> class.
+    /// </summary>
+    /// <param name="rootScope">The root <see cref="Scope"/>.</param>
+    public RootScopeLifetime(Scope rootScope)
+        => this.rootScope = rootScope;
+
+    /// <inheritdoc/>
+    [ExcludeFromCodeCoverage]
+    public object GetInstance(Func<object> createInstance, Scope scope)
+        => throw new NotImplementedException("Uses optimized non closing method");
+
+    /// <inheritdoc/>
+    public ILifetime Clone()
+        => new PerRootScopeLifetime(rootScope);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable IDE0060
+    public object GetInstance(GetInstanceDelegate createInstance, Scope scope, object[] arguments)
+    {
+#pragma warning restore IDE0060
+        if (instance != null)
+        {
+            return instance;
+        }
+
+        lock (syncRoot)
+        {
+            if (instance == null)
+            {
+                instance = createInstance(arguments, rootScope);
+                RegisterForDisposal(instance);
+            }
+        }
+
+        return instance;
+    }
+
+    private void RegisterForDisposal(object instance)
+    {
+        if (instance is IDisposable disposable)
+        {
+            rootScope.TrackInstance(disposable);
+        }
+        else if (instance is IAsyncDisposable asyncDisposable)
+        {
+            rootScope.TrackInstance(asyncDisposable);
+        }
+    }
+}

--- a/src/LightInject.Tests/MicrosoftTests.cs
+++ b/src/LightInject.Tests/MicrosoftTests.cs
@@ -614,7 +614,7 @@ public class MicrosoftTests : TestBase
         Assert.Equal(2, allServices.Count);
         Assert.Same(poco, allServices[0].Value);
         Assert.Same(poco, allServices[1].Value);
-        Assert.Equal(1, constrainedServices.Count);
+        Assert.Single(constrainedServices);
         Assert.Same(singletonService, constrainedServices[0].Value);
     }
 
@@ -630,7 +630,7 @@ public class MicrosoftTests : TestBase
         // Act
         var constrainedServices = rootScope.GetAllInstances<IFakeOpenGenericService<IFakeSingletonService>>().ToList();
         // Assert
-        Assert.Equal(0, constrainedServices.Count);
+        Assert.Empty(constrainedServices);
     }
 
     [Fact]
@@ -655,7 +655,7 @@ public class MicrosoftTests : TestBase
         Assert.Equal(2, allServices.Count);
         Assert.Same(enumerableVal, allServices[0].Value);
         Assert.Same(enumerableVal, allServices[1].Value);
-        Assert.Equal(1, constrainedServices.Count);
+        Assert.Single(constrainedServices);        
         Assert.Same(singletonService, constrainedServices[0].Value);
     }
 
@@ -684,7 +684,7 @@ public class MicrosoftTests : TestBase
         Assert.Equal(2, allServices.Count);
         Assert.Same(classInheritingClassInheritingAbstractClass, allServices[0].Value);
         Assert.Same(classInheritingClassInheritingAbstractClass, allServices[1].Value);
-        Assert.Equal(1, constrainedServices.Count);
+        Assert.Single(constrainedServices);
         Assert.Same(poco, constrainedServices[0].Value);
     }
 
@@ -729,8 +729,8 @@ public class MicrosoftTests : TestBase
         // Assert
         Assert.IsType<FakeService>(service);
         Assert.Equal(2, services.Length);
-        Assert.True(services.Any(s => s.GetType() == typeof(FakeService)));
-        Assert.True(services.Any(s => s.GetType() == typeof(FakeOpenGenericService<PocoClass>)));
+        Assert.Contains(services, s => s.GetType() == typeof(FakeService));                
+        Assert.Contains(services, s => s.GetType() == typeof(FakeOpenGenericService<PocoClass>));
     }
 
 

--- a/src/LightInject.Tests/MicrosoftTestsWithoutVariance.cs
+++ b/src/LightInject.Tests/MicrosoftTestsWithoutVariance.cs
@@ -1,0 +1,23 @@
+
+namespace LightInject.Tests;
+
+public class MicrosoftTestsWithoutVariance : MicrosoftTests
+{
+    internal override IServiceContainer CreateContainer()
+    {
+        var container = new ServiceContainer(options =>
+         {
+             options.AllowMultipleRegistrations = true;
+             options.EnableCurrentScope = false;
+             options.OptimizeForLargeObjectGraphs = false;
+             options.EnableOptionalArguments = false;
+             options.EnableVariance = false;
+         })
+        {
+            AssemblyScanner = new NoOpAssemblyScanner()
+        };
+        container.ConstructorDependencySelector = new AnnotatedConstructorDependencySelector();
+        container.ConstructorSelector = new AnnotatedConstructorSelector(container.CanGetInstance);
+        return container;
+    }
+}

--- a/src/LightInject.Tests/MicrosoftTestsWithoutVariance.cs
+++ b/src/LightInject.Tests/MicrosoftTestsWithoutVariance.cs
@@ -7,7 +7,7 @@ public class MicrosoftTestsWithoutVariance : MicrosoftTests
     {
         var container = new ServiceContainer(options =>
          {
-             options.AllowMultipleRegistrations = true;
+             options.EnableMicrosoftCompatibility = true;
              options.EnableCurrentScope = false;
              options.OptimizeForLargeObjectGraphs = false;
              options.EnableOptionalArguments = false;

--- a/src/LightInject.Tests/OrderedTests.cs
+++ b/src/LightInject.Tests/OrderedTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Diagnostics.Contracts;
+using System.Linq;
 using LightInject.SampleLibrary;
 using Xunit;
 
@@ -38,7 +39,7 @@ namespace LightInject.Tests
         public void ShouldOrderServicesWhenRegisteredAsOrdered()
         {
             var container = CreateContainer();
-            container.RegisterOrdered(typeof(IFoo), new[] {typeof(Foo1), typeof(Foo2), typeof(Foo3)},
+            container.RegisterOrdered(typeof(IFoo), new[] { typeof(Foo1), typeof(Foo2), typeof(Foo3) },
                 type => new PerContainerLifetime());
 
             var instances = container.GetAllInstances<IFoo>().ToArray();
@@ -47,6 +48,19 @@ namespace LightInject.Tests
             Assert.IsType<Foo2>(instances[1]);
             Assert.IsType<Foo3>(instances[2]);
         }
+
+        [Fact]
+        public void ShouldResolveLastService()
+        {
+            var container = CreateContainer();
+            var foo1 = new Foo();
+            var foo2 = new Foo();
+            container.RegisterInstance(foo1);
+            container.RegisterInstance(foo2);
+
+            var test = container.AvailableServices;
+        }
+
 
         [Fact]
         public void ShouldOrderOpenGenericServicesWhenRegisteredAsOrdered()
@@ -58,7 +72,7 @@ namespace LightInject.Tests
             var instances = container.GetAllInstances<IFoo<int>>().ToArray();
             Assert.IsType<Foo1<int>>(instances[0]);
             Assert.IsType<Foo2<int>>(instances[1]);
-            Assert.IsType<Foo3<int>>(instances[2]);            
+            Assert.IsType<Foo3<int>>(instances[2]);
         }
 
         [Fact]
@@ -66,7 +80,7 @@ namespace LightInject.Tests
         {
             var container = CreateContainer();
             container.RegisterOrdered(typeof(IFoo<>), new[] { typeof(Foo1<>), typeof(Foo2<>), typeof(Foo3<>) },
-                type => new PerContainerLifetime(), i => $"A{i.ToString().PadLeft(3,'0')}");
+                type => new PerContainerLifetime(), i => $"A{i.ToString().PadLeft(3, '0')}");
 
             var services = container.AvailableServices.Where(sr => sr.ServiceType == typeof(IFoo<>))
                 .OrderBy(sr => sr.ServiceName).ToArray();
@@ -89,5 +103,5 @@ namespace LightInject.Tests
     }
 
 
-  
+
 }

--- a/src/LightInject.Tests/SampleServices/Foo.cs
+++ b/src/LightInject.Tests/SampleServices/Foo.cs
@@ -8,6 +8,7 @@ namespace LightInject.SampleLibrary
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
 
     public interface IFooWithProperty
     {
@@ -143,7 +144,7 @@ namespace LightInject.SampleLibrary
 
     public class FooWithDependency : IFoo
     {
-        public FooWithDependency(IBar bar)
+        public FooWithDependency([FromKeyedServices("AnotherBar")] IBar bar)
         {
             Bar = bar;
         }

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -138,7 +138,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_ValueTypeAsSingeton_ReturnsValue()
+        public void GetInstance_ValueTypeAsSingleton_ReturnsValue()
         {
             var container = CreateContainer();
             container.Register<int>(factory => 42, new PerContainerLifetime());
@@ -690,14 +690,7 @@ namespace LightInject.Tests
             var instance2 = factory();
             Assert.NotSame(instance1, instance2);
         }
-
-        //[Fact]
-        //public void GetInstance_Func_FailesWhenUnderlyingServiceIsMissing()
-        //{
-        //    var container = CreateContainer(new ContainerOptions(){EnableStrictDeferredResolution = true});
-        //    Assert.Throws<InvalidOperationException>(() => container.GetInstance<Func<IFoo>>());
-        //}
-
+        
         #endregion
         #region Func Factory
 
@@ -774,7 +767,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_Funcfactory_ReturnsInstanceWithDependencies()
+        public void GetInstance_FuncFactory_ReturnsInstanceWithDependencies()
         {
             var container = CreateContainer();
             container.Register<IBar>(c => new Bar());
@@ -784,7 +777,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_FuncFactoryWithReferenceTypeDepenedency_ReturnsInstanceWithDependencies()
+        public void GetInstance_FuncFactoryWithReferenceTypeDependency_ReturnsInstanceWithDependencies()
         {
             var container = CreateContainer();
             container.Register<IFoo>(c => new FooWithReferenceTypeDependency("SomeStringValue"));
@@ -793,7 +786,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_FuncFactoryWithValueTypeDepenedency_ReturnsInstanceWithDependencies()
+        public void GetInstance_FuncFactoryWithValueTypeDependency_ReturnsInstanceWithDependencies()
         {
             var container = CreateContainer();
             container.Register<IFoo>(c => new FooWithValueTypeDependency(42));
@@ -802,7 +795,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_FuncFactoryWithEnumDepenedency_ReturnsInstanceWithDependencies()
+        public void GetInstance_FuncFactoryWithEnumDependency_ReturnsInstanceWithDependencies()
         {
             var container = CreateContainer();
             container.Register<IFoo>(c => new FooWithEnumDependency(Encoding.UTF8));
@@ -1013,7 +1006,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_KnownOpenGenercEnumerable_ReturnsKnownEnumerable()
+        public void GetInstance_KnownOpenGenericEnumerable_ReturnsKnownEnumerable()
         {
             var container = CreateContainer();
             container.Register(typeof(IEnumerable<>), typeof(FooList<>));
@@ -1081,7 +1074,7 @@ namespace LightInject.Tests
         }
 
         [Fact]
-        public void GetInstance_UsingFallBack_ProvidesServiceReuest()
+        public void GetInstance_UsingFallBack_ProvidesServiceRequest()
         {
             var container = CreateContainer();
             ServiceRequest serviceRequest = null;

--- a/src/LightInject.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Tests/ServiceContainerTests.cs
@@ -83,13 +83,7 @@ namespace LightInject.Tests
             Assert.Equal("instance", exception.ParamName);
         }
 
-        [Fact]
-        public void RegisterInstance_NullServiceName_ThrowsArgumentNullException()
-        {
-            var container = CreateContainer();
-            var exception = Assert.Throws<ArgumentNullException>(() => container.RegisterInstance(typeof(object), new object(), null));
-            Assert.Equal("serviceName", exception.ParamName);
-        }
+
         #endregion
 
 

--- a/src/LightInject.Tests/ServiceKeyTests.cs
+++ b/src/LightInject.Tests/ServiceKeyTests.cs
@@ -1,0 +1,39 @@
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests;
+
+
+public class ServiceKeyTests
+{
+    [Fact]
+    public void ShouldBeEqualWhenServiceTypeAndServiceNameIsSame()
+    {
+        var serviceKey1 = new ServiceKey(typeof(IFoo), "Foo");
+        var serviceKey2 = new ServiceKey(typeof(IFoo), "Foo");
+        Assert.Equal(serviceKey1, serviceKey2);
+    }
+
+    [Fact]
+    public void ShouldNotBeEqualWhenServiceTypeIsDifferent()
+    {
+        var serviceKey1 = new ServiceKey(typeof(IFoo), "Foo");
+        var serviceKey2 = new ServiceKey(typeof(IBar), "Foo");
+        Assert.NotEqual(serviceKey1, serviceKey2);
+    }
+
+    [Fact]
+    public void ShouldNotBeEqualWhenServiceNameIsDifferent()
+    {
+        var serviceKey1 = new ServiceKey(typeof(IFoo), "Foo");
+        var serviceKey2 = new ServiceKey(typeof(IFoo), "Bar");
+        Assert.NotEqual(serviceKey1, serviceKey2);
+    }
+
+    [Fact]
+    public void ShouldHaveToStringWithServiceTypeAndServiceName()
+    {
+        var serviceKey = new ServiceKey(typeof(IFoo), "Foo");
+        Assert.Equal("LightInject.SampleLibrary.IFoo - Foo", serviceKey.ToString());
+    }
+}

--- a/src/LightInject.Tests/ServiceRegistrationEqualsTests.cs
+++ b/src/LightInject.Tests/ServiceRegistrationEqualsTests.cs
@@ -1,0 +1,65 @@
+using LightInject.SampleLibrary;
+using Xunit;
+
+namespace LightInject.Tests;
+
+public class ServiceRegistrationEqualsTests
+{
+    [Fact]
+    public void ShouldBeEqualWhenServiceTypeAndServiceNameAreTheSame()
+    {
+        var serviceRegistration1 = new ServiceRegistration
+        {
+            ServiceType = typeof(int),
+            ServiceName = string.Empty
+        };
+
+        var serviceRegistration2 = new ServiceRegistration
+        {
+            ServiceType = typeof(int),
+            ServiceName = string.Empty
+        };
+
+        Assert.Equal(serviceRegistration1, serviceRegistration2);
+    }
+
+    [Fact]
+    public void ShouldNotBeEqualIfImplementingTypeIsDifferent()
+    {
+        var serviceRegistration1 = new ServiceRegistration
+        {
+            ServiceType = typeof(IFoo),
+            ServiceName = string.Empty,
+            ImplementingType = typeof(Foo)
+        };
+
+        var serviceRegistration2 = new ServiceRegistration
+        {
+            ServiceType = typeof(IFoo),
+            ServiceName = string.Empty,
+            ImplementingType = typeof(AnotherFoo)
+        };
+
+        Assert.NotEqual(serviceRegistration1, serviceRegistration2);
+    }
+
+    [Fact]
+    public void ShouldNotBeEqualWithMixedImplementingTypeAndFactoryExpression()
+    {
+        var serviceRegistration1 = new ServiceRegistration
+        {
+            ServiceType = typeof(IFoo),
+            ServiceName = string.Empty,
+            ImplementingType = typeof(Foo)
+        };
+
+        var serviceRegistration2 = new ServiceRegistration
+        {
+            ServiceType = typeof(IFoo),
+            ServiceName = string.Empty,
+            FactoryExpression = (IServiceFactory f) => new Foo()
+        };
+
+        Assert.NotEqual(serviceRegistration1, serviceRegistration2);
+    }
+}

--- a/src/LightInject.Tests/ServiceRegistrationTests.cs
+++ b/src/LightInject.Tests/ServiceRegistrationTests.cs
@@ -174,15 +174,13 @@ namespace LightInject.Tests
         {
             string message = null;
             var container = new ServiceContainer(new ContainerOptions { LogFactory = t => m => message = m.Message });
-
-            //SampleTraceListener sampleTraceListener = new SampleTraceListener(m => message = m);
+            
             try
             {
-                ///  Trace.Listeners.Add(sampleTraceListener);
                 container.Register<IFoo, Foo>();
                 container.GetInstance<IFoo>();
                 container.Register<IFoo, Foo>();
-                Assert.StartsWith("Cannot overwrite existing serviceregistration", message);
+                Assert.StartsWith("Cannot overwrite existing service registration", message);
             }
             finally
             {

--- a/src/LightInject.Tests/TypeNameFormatter.cs
+++ b/src/LightInject.Tests/TypeNameFormatter.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Text;
+
+namespace LightInject;
+
+/// <summary>
+/// [assembly: DebuggerDisplay("{LightInject.TypeNameFormatter.GetHumanFriendlyTypeName(this)}", Target = typeof(Type))]
+/// </summary>    
+public static class TypeNameFormatter
+{
+    public static string GetHumanFriendlyTypeName(Type type)
+    {
+        StringBuilder humanFriendlyName = new StringBuilder();
+        if (type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+
+            humanFriendlyName.Append(type.Name.Substring(0, type.Name.IndexOf('`')));
+            humanFriendlyName.Append('<');
+            foreach (Type argument in type.GenericTypeArguments)
+            {
+                humanFriendlyName.Append(GetHumanFriendlyTypeName(argument));
+                humanFriendlyName.Append(", ");
+            }
+            humanFriendlyName.Remove(humanFriendlyName.Length - 2, 2);
+            humanFriendlyName.Append('>');
+        }
+        else if (type.IsGenericTypeDefinition)
+        {
+            humanFriendlyName.Append(type.Name.Substring(0, type.Name.IndexOf('`')));
+            humanFriendlyName.Append('<');
+            foreach (Type parameter in type.GetGenericArguments())
+            {
+                humanFriendlyName.Append(parameter.Name);
+                humanFriendlyName.Append(", ");
+            }
+            humanFriendlyName.Remove(humanFriendlyName.Length - 2, 2);
+            humanFriendlyName.Append('>');
+        }
+        else
+        {
+            humanFriendlyName.Append(type.Name);
+        }
+        return humanFriendlyName.ToString();
+    }
+}

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -3852,15 +3852,24 @@ namespace LightInject
             if (options.AllowMultipleRegistrations)
             {
                 var emitters = allEmitters.GetOrAdd(new ServiceKey(serviceType, serviceName), _ => new List<EmitMethodInfo>());
+                if (emitters.Count == 0)
+                {
+                    return CreateEmitMethodForUnknownService(serviceType, serviceName);
+                }
                 if (string.IsNullOrWhiteSpace(serviceName))
                 {
-                    if (emitters.Count > 1)
+                    if (emitters.Count == 1)
+                    {
+                        return emitters[0].EmitMethod;
+                    }
+                    else if (emitters.Count > 1)
                     {
                         return emitters.Last().EmitMethod;
                     }
                     else
                     {
-                        serviceName = string.Empty;
+                        return null;
+                        // serviceName = string.Empty;
                     }
                 }
             }
@@ -4771,7 +4780,7 @@ namespace LightInject
 
         private bool CanRedirectRequestForDefaultServiceToSingleNamedService(Type serviceType, string serviceName)
         {
-            return string.IsNullOrEmpty(serviceName) && GetEmitMethods(serviceType).Count == 1;
+            return string.IsNullOrEmpty(serviceName) && GetEmitMethods(serviceType).Count == 1 && options.AllowMultipleRegistrations == false;
         }
 
         private ConstructionInfo GetConstructionInfo(Registration registration)

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -3685,7 +3685,7 @@ namespace LightInject
 
         private static void PushRuntimeArguments(IEmitter emitter)
         {
-            MethodInfo loadMethod = typeof(RuntimeArgumentsLoader).GetTypeInfo().GetDeclaredMethod("Load");
+            MethodInfo loadMethod = RuntimeArgumentsLoader.LoadMethod;
             emitter.Emit(OpCodes.Ldarg_0);
             emitter.Emit(OpCodes.Call, loadMethod);
         }

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4838,16 +4838,12 @@ namespace LightInject
                 {
                     if (serviceName == "*")
                     {
-                        // var serviceKeys = allEmitters.Keys.Where(k => actualServiceType.IsAssignableFrom(k.ServiceType) && k.ServiceName.Length > 0).ToList();
-
-                        // var query = from r in allRegistrations.SelectMany(r => r.Value)
-                        //             join k in serviceKeys on new ServiceKey(r.ServiceType, r.ServiceName) equals k
-                        //             select r;
-
-
-                        // allRegistrations.Join(serviceKeys, r => new ServiceKey(r.ServiceType, r.ServiceName), k => k, (r, k) => r).ToList().ForEach(r => Register(r));
-
                         emitMethods = allEmitters.Keys.Where(k => actualServiceType.IsAssignableFrom(k.ServiceType) && k.ServiceName.Length > 0).SelectMany(k => allEmitters[k]).Where(emi => !emi.CreatedFromWildcardService).OrderBy(emi => emi.RegistrationOrder).Select(emi => emi.EmitMethod).ToList();
+                    }
+                    else
+                    if (serviceName.Length > 0)
+                    {
+                        emitMethods = allEmitters.Keys.Where(k => actualServiceType.IsAssignableFrom(k.ServiceType) && k.ServiceName == serviceName || k.ServiceName == "*").SelectMany(k => allEmitters[k]).Where(emi => !emi.CreatedFromWildcardService).OrderBy(emi => emi.RegistrationOrder).Select(emi => emi.EmitMethod).ToList();
                     }
                     else
                     {

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4993,8 +4993,29 @@ namespace LightInject
             }
             else
             {
-                // TODO Make tests with variance off. 
-                emitMethods = GetEmitMethods(actualServiceType).OrderBy(kv => kv.Key).Select(kv => kv.Value).ToList();
+                if (options.AllowMultipleRegistrations)
+                {
+                    if (serviceName == "*")
+                    {
+                        emitMethods = allEmitters.Keys.Where(k => actualServiceType == k.ServiceType && k.ServiceName.Length > 0).SelectMany(k => allEmitters[k]).Where(emi => !emi.CreatedFromWildcardService).OrderBy(emi => emi.RegistrationOrder).Select(emi => emi.EmitMethod).ToList();
+                    }
+                    else
+                   if (serviceName.Length > 0)
+                    {
+                        emitMethods = allEmitters.Keys.Where(k => actualServiceType == k.ServiceType && k.ServiceName == serviceName || k.ServiceName == "*").SelectMany(k => allEmitters[k]).Where(emi => !emi.CreatedFromWildcardService).OrderBy(emi => emi.RegistrationOrder).Select(emi => emi.EmitMethod).ToList();
+                    }
+                    else
+                    {
+                        var serviceKeys = allEmitters.Keys.Where(k => actualServiceType == k.ServiceType && k.ServiceName == serviceName).ToList();
+                        emitMethods = serviceKeys.SelectMany(k => allEmitters[k]).OrderBy(emi => emi.RegistrationOrder).Select(emi => emi.EmitMethod).ToList();
+                    }
+                }
+                else
+                {
+                    // TODO Make tests with variance off. 
+                    emitMethods = GetEmitMethods(actualServiceType).OrderBy(kv => kv.Key).Select(kv => kv.Value).ToList();
+                }
+
             }
 
             if (dependencyStack.Count > 0 && emitMethods.Contains(dependencyStack.Peek()))

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -7164,6 +7164,7 @@ namespace LightInject
         /// <param name="disposable">The <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/> object to register.</param>
         public void TrackInstance(object disposable)
         {
+            Console.WriteLine(disposable.GetType() + " " + disposable.ToString());
             if (disposable is Scope)
             {
                 return;
@@ -7194,6 +7195,8 @@ namespace LightInject
                     {
                         if (disposedObjects.Add(disposable))
                         {
+                            Console.WriteLine("Disposing " + disposable.GetType() + " " + disposable.ToString());
+
                             disposable.Dispose();
                         }
                     }

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -3341,24 +3341,6 @@ namespace LightInject
         }
 
         /// <inheritdoc/>
-        public IServiceRegistry RegisterOrdered(Type serviceType, ServiceRegistration[] serviceRegistrations)
-        {
-            List<Action<IEmitter>> emitters = new List<Action<IEmitter>>();
-            foreach (var registration in serviceRegistrations)
-            {
-                var emitMethod = ResolveEmitMethod(registration);
-                emitters.Add(emitMethod);
-            }
-
-            Action<IEmitter> emitAction = (emitter) => EmitEnumerable(emitters.ToArray(), serviceType, emitter);
-
-            Type enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
-            registrationOrder++;
-            RegisterEmitMethod(enumerableType, string.Empty, registrationOrder, emitAction);
-            return this;
-        }
-
-        /// <inheritdoc/>
         public void Compile(Func<ServiceRegistration, bool> predicate)
         {
             var rootServices = AvailableServices.Where(predicate).ToArray();
@@ -7074,7 +7056,7 @@ namespace LightInject
         /// <summary>
         /// Registers the <paramref name="disposable"/> so that it is disposed when the scope is completed.
         /// </summary>
-        /// <param name="disposable">The <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/> object to register.</param>
+        /// <param name="disposable">The <see cref="IDisposable"/> to register.</param>
         public void TrackInstance(object disposable)
         {
             if (disposable is Scope)

--- a/src/LightInject/LightInject.cs
+++ b/src/LightInject/LightInject.cs
@@ -4675,7 +4675,7 @@ namespace LightInject
             Type elementType = TypeHelper.GetElementType(serviceType);
             Type closedGenericReadOnlyCollectionType = typeof(ReadOnlyCollection<>).MakeGenericType(elementType);
             ConstructorInfo constructorInfo =
-                closedGenericReadOnlyCollectionType.GetTypeInfo().DeclaredConstructors.Single();
+                closedGenericReadOnlyCollectionType.GetTypeInfo().DeclaredConstructors.Where(c => c.GetParameters().Length == 1).Single();
 
             Action<IEmitter> listEmitMethod = CreateEmitMethodForListServiceRequest(serviceType, serviceName);
 

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -41,10 +41,10 @@
     </When>
   </Choose>
   <ItemGroup>
-    <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference> -->
+    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/LightInject/LightInject.csproj
+++ b/src/LightInject/LightInject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;netcoreapp3.1;net462</TargetFrameworks>
     <Version>6.6.4</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://www.lightinject.net</PackageProjectUrl>
@@ -34,7 +34,7 @@
     </When>
   </Choose>
   <Choose>
-    <When Condition=" '$(TargetFramework)'=='net6.0' Or '$(TestTargetFramework)'=='net6.0'">
+    <When Condition=" '$(TargetFramework)'=='net8.0' Or '$(TestTargetFramework)'=='net8.0'">
       <PropertyGroup>
         <DefineConstants>USE_ASYNCDISPOSABLE</DefineConstants>
       </PropertyGroup>


### PR DESCRIPTION
This PR adds the `EnableMicrosoftCompatibility` option which makes LightInject compatible with `Microsoft.Extensions.DependencyInjection`. 

This includes support for keyed services which is now part of `Microsoft.Extensions.DependencyInjection`